### PR TITLE
Set up front end testing

### DIFF
--- a/packages/client/App.tsx
+++ b/packages/client/App.tsx
@@ -1,11 +1,11 @@
 import { DripsyProvider } from 'dripsy';
 import { StatusBar } from 'expo-status-bar';
-import React, { useState } from 'react';
+import React from 'react';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
-import { colorPalette } from './constants/Colors';
 import { MusicPlayerContextProvider } from './contexts/MusicPlayerContext';
 import useCachedResources from './hooks/useCachedResources';
 import { useSocket } from './hooks/useSocket';
+import { useTheme } from './hooks/useTheme';
 import Navigation from './navigation';
 
 export type SizeTerms = 'xs' | 's' | 'm' | 'l' | 'xl';
@@ -13,44 +13,8 @@ export type BackgroundTerms = 'primary' | 'seconday' | 'white' | 'text';
 
 const App: React.FC = () => {
     const socket = useSocket();
-    const [colorScheme, setColorScheme] = useState<'dark' | 'light'>('dark');
     const isLoadingComplete = useCachedResources();
-    const palette = colorPalette(colorScheme);
-    const theme = {
-        colors: {
-            ...palette,
-        },
-        space: {
-            none: 0,
-            xs: 2,
-            s: 4,
-            m: 8,
-            l: 16,
-            xl: 24,
-        },
-        borderWidths: {
-            s: 1,
-            m: 2,
-            l: 3,
-        },
-        fontSizes: {
-            xs: 14,
-            s: 16,
-            m: 20,
-            l: 24,
-            xl: 32,
-        },
-        radii: {
-            s: 5,
-            m: 10,
-            l: 15,
-            full: 9999,
-        },
-    };
-
-    const toggleColorScheme = () => {
-        setColorScheme(colorScheme === 'dark' ? 'light' : 'dark');
-    };
+    const { colorScheme, theme, toggleColorScheme } = useTheme();
 
     if (!isLoadingComplete) {
         return null;

--- a/packages/client/__tests__/SearchTrackScreen.test.tsx
+++ b/packages/client/__tests__/SearchTrackScreen.test.tsx
@@ -7,7 +7,7 @@ function noop() {
     return undefined;
 }
 
-test(`Let's user search for a song, shows the results and let's the user click on a song, that redirects them to results screen`, async () => {
+test(`Goes to Search a Track screen, searches a track and sees search results`, async () => {
     const { getByText, getByPlaceholderText } = render(
         <NavigationContainer>
             <RootNavigator colorScheme="dark" toggleColorScheme={noop} />
@@ -20,6 +20,7 @@ test(`Let's user search for a song, shows the results and let's the user click o
     expect(searchScreenLink).toBeTruthy();
 
     fireEvent.press(searchScreenLink);
+
     await waitFor(() => expect(getByText(/search.*track/i)).toBeTruthy());
 
     const searchInput = getByPlaceholderText(/search.*track/i);
@@ -27,6 +28,15 @@ test(`Let's user search for a song, shows the results and let's the user click o
 
     const SEARCH_QUERY = 'Benjamin Biolay';
 
+    /**
+     * To simulate a real interaction with a text input, we need to:
+     * 1. Focus it
+     * 2. Change its text
+     * 3. Submit the changes
+     */
+    fireEvent(searchInput, 'focus');
     fireEvent.changeText(searchInput, SEARCH_QUERY);
     fireEvent(searchInput, 'submitEditing');
+
+    await waitFor(() => expect(getByText(/results/i)).toBeTruthy());
 });

--- a/packages/client/__tests__/SearchTrackScreen.test.tsx
+++ b/packages/client/__tests__/SearchTrackScreen.test.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '../tests/tests-utils';
+import { RootNavigator } from '../navigation';
+import { NavigationContainer } from '@react-navigation/native';
+
+function noop() {
+    return undefined;
+}
+
+test(`Let's user search for a song, shows the results and let's the user click on a song, that redirects them to results screen`, async () => {
+    const { getByText, getByPlaceholderText } = render(
+        <NavigationContainer>
+            <RootNavigator colorScheme="dark" toggleColorScheme={noop} />
+        </NavigationContainer>,
+    );
+
+    expect(getByText(/this.*is.*home/i)).toBeTruthy();
+
+    const searchScreenLink = getByText(/search/i);
+    expect(searchScreenLink).toBeTruthy();
+
+    fireEvent.press(searchScreenLink);
+    await waitFor(() => expect(getByText(/search.*track/i)).toBeTruthy());
+
+    const searchInput = getByPlaceholderText(/search.*track/i);
+    expect(searchInput).toBeTruthy();
+
+    const SEARCH_QUERY = 'Benjamin Biolay';
+
+    fireEvent.changeText(searchInput, SEARCH_QUERY);
+    fireEvent(searchInput, 'submitEditing');
+});

--- a/packages/client/constants/Endpoints.ts
+++ b/packages/client/constants/Endpoints.ts
@@ -1,7 +1,9 @@
 import { Platform } from 'react-native';
 
+type ApplicationEnvironment = 'development' | 'prod';
+
 function computeServerEndpoint(
-    env: 'development' | 'prod',
+    env: ApplicationEnvironment,
     os: 'ios' | 'android' | 'windows' | 'macos' | 'web',
 ): string {
     if (env !== 'development') {
@@ -20,7 +22,10 @@ function computeServerEndpoint(
     }
 }
 
+const currentEnvironment: ApplicationEnvironment = (process.env.NODE_ENV ??
+    'development') as ApplicationEnvironment;
+
 export const SERVER_ENDPOINT = computeServerEndpoint(
-    process.env.NODE_ENV ?? 'development',
+    currentEnvironment,
     Platform.OS,
 );

--- a/packages/client/constants/Endpoints.ts
+++ b/packages/client/constants/Endpoints.ts
@@ -1,21 +1,26 @@
 import { Platform } from 'react-native';
 
-export const SERVER_ENDPOINT = ((
+function computeServerEndpoint(
     env: 'development' | 'prod',
     os: 'ios' | 'android' | 'windows' | 'macos' | 'web',
-) => {
-    if (env === 'development') {
-        switch (os) {
-            case 'ios':
-                return 'http://127.0.0.1:3333';
-            case 'android':
-                return 'http://10.0.2.2:3333';
-            case 'web':
-                return 'http://localhost:3333';
-            default:
-                throw new Error('os not supported');
-        }
-    } else {
+): string {
+    if (env !== 'development') {
         return 'http://localhost:3333'; //TODO TO BE DEFINED LATER
     }
-})(process.env.NODE_ENV ?? 'development', Platform.OS);
+
+    switch (os) {
+        case 'ios':
+            return 'http://127.0.0.1:3333';
+        case 'android':
+            return 'http://10.0.2.2:3333';
+        case 'web':
+            return 'http://localhost:3333';
+        default:
+            throw new Error('os not supported');
+    }
+}
+
+export const SERVER_ENDPOINT = computeServerEndpoint(
+    process.env.NODE_ENV ?? 'development',
+    Platform.OS,
+);

--- a/packages/client/contexts/MusicPlayerContext.tsx
+++ b/packages/client/contexts/MusicPlayerContext.tsx
@@ -1,6 +1,6 @@
 import { useMachine, useSelector } from '@xstate/react';
 import React, { useContext } from 'react';
-import { Socket } from 'socket.io-client';
+import { Socket } from '../services/websockets';
 import { Sender, State } from 'xstate';
 import {
     AppMusicPlayerMachineEvent,

--- a/packages/client/hooks/useSocket.ts
+++ b/packages/client/hooks/useSocket.ts
@@ -3,7 +3,7 @@ import {
     AllServerToClientEvents,
 } from '@musicroom/types';
 import { useMemo } from 'react';
-import { io, Socket } from 'socket.io-client';
+import { io, Socket } from '../services/websockets';
 import { SERVER_ENDPOINT } from '../constants/Endpoints';
 
 export type SocketClient = Socket<

--- a/packages/client/hooks/useTheme.ts
+++ b/packages/client/hooks/useTheme.ts
@@ -1,0 +1,57 @@
+import { Theme } from 'dripsy';
+import { useState } from 'react';
+import { colorPalette } from '../constants/Colors';
+
+type ApplicationTheme = 'dark' | 'light';
+
+interface UseThemeReturn {
+    colorScheme: ApplicationTheme;
+    theme: Theme;
+    toggleColorScheme: () => void;
+}
+
+export function useTheme(): UseThemeReturn {
+    const [colorScheme, setColorScheme] = useState<ApplicationTheme>('dark');
+    const palette = colorPalette(colorScheme);
+    const theme: Theme = {
+        colors: {
+            ...palette,
+        },
+        space: {
+            none: 0,
+            xs: 2,
+            s: 4,
+            m: 8,
+            l: 16,
+            xl: 24,
+        },
+        borderWidths: {
+            s: 1,
+            m: 2,
+            l: 3,
+        },
+        fontSizes: {
+            xs: 14,
+            s: 16,
+            m: 20,
+            l: 24,
+            xl: 32,
+        },
+        radii: {
+            s: 5,
+            m: 10,
+            l: 15,
+            full: 9999,
+        },
+    };
+
+    const toggleColorScheme = () => {
+        setColorScheme(colorScheme === 'dark' ? 'light' : 'dark');
+    };
+
+    return {
+        colorScheme,
+        theme,
+        toggleColorScheme,
+    };
+}

--- a/packages/client/jest.config.js
+++ b/packages/client/jest.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+    preset: 'jest-expo',
+    transformIgnorePatterns: [
+        'node_modules/(?!(jest-)?react-native|react-clone-referenced-element|dripsy|@dripsy/.*|@react-native-community|expo(nent)?|@expo(nent)?/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|@sentry/.*)',
+    ],
+    testPathIgnorePatterns: ['/node_modules/', 'dist'],
+    setupFilesAfterEnv: ['./jest.setup.ts'],
+};

--- a/packages/client/jest.config.js
+++ b/packages/client/jest.config.js
@@ -4,5 +4,5 @@ module.exports = {
         'node_modules/(?!(jest-)?react-native|react-clone-referenced-element|dripsy|@dripsy/.*|@react-native-community|expo(nent)?|@expo(nent)?/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|@sentry/.*)',
     ],
     testPathIgnorePatterns: ['/node_modules/', 'dist'],
-    setupFilesAfterEnv: ['./jest.setup.ts'],
+    setupFilesAfterEnv: ['./jest.setup.ts', './tests/global-mocks.ts'],
 };

--- a/packages/client/jest.setup.ts
+++ b/packages/client/jest.setup.ts
@@ -1,0 +1,36 @@
+import '@testing-library/jest-native';
+
+jest.setTimeout(20_000);
+
+jest.mock('react-native-reanimated', () => {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const Reanimated = require('react-native-reanimated/mock');
+
+    Reanimated.default.call = () => {
+        return undefined;
+    };
+
+    return Reanimated as unknown;
+});
+
+jest.mock('moti', () => {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { View } = require('react-native');
+
+    return {
+        View,
+    };
+});
+
+// Replace websockets service with its mock version.
+// In the mock version, we provide an implementation for serverSocket, which permits
+// to simulate bidirectional communication.
+jest.mock('./services/websockets.ts');
+
+// Necessary to prevent errors from expo-linking
+jest.mock('./navigation/LinkingConfiguration.ts', () => {
+    return {};
+});
+
+// Silence the warning: Animated: `useNativeDriver` is not supported because the native animated module is missing
+jest.mock('react-native/Libraries/Animated/src/NativeAnimatedHelper');

--- a/packages/client/jest.setup.ts
+++ b/packages/client/jest.setup.ts
@@ -1,37 +1,5 @@
-/* eslint-disable */
 import '@testing-library/jest-native';
-import fetch from 'node-fetch';
 import { server } from './tests/server/test-server';
-
-// The Fetch API is not available in Expo Jest environment (which is Node.js).
-// We use node-fetch polyfill and set the global reference to it.
-global.fetch = fetch;
-
-// MSW uses the LocalStorage internally. In order for MSW to work we need
-// to mock the LocalStorage API.
-class LocalStorageMock {
-    constructor() {
-        this.store = {};
-    }
-
-    clear() {
-        this.store = {};
-    }
-
-    getItem(key) {
-        return this.store[key] || null;
-    }
-
-    setItem(key, value) {
-        this.store[key] = String(value);
-    }
-
-    removeItem(key) {
-        delete this.store[key];
-    }
-}
-
-global.localStorage = new LocalStorageMock();
 
 jest.setTimeout(20_000);
 

--- a/packages/client/jest.setup.ts
+++ b/packages/client/jest.setup.ts
@@ -1,4 +1,37 @@
+/* eslint-disable */
 import '@testing-library/jest-native';
+import fetch from 'node-fetch';
+import { server } from './tests/server/test-server';
+
+// The Fetch API is not available in Expo Jest environment (which is Node.js).
+// We use node-fetch polyfill and set the global reference to it.
+global.fetch = fetch;
+
+// MSW uses the LocalStorage internally. In order for MSW to work we need
+// to mock the LocalStorage API.
+class LocalStorageMock {
+    constructor() {
+        this.store = {};
+    }
+
+    clear() {
+        this.store = {};
+    }
+
+    getItem(key) {
+        return this.store[key] || null;
+    }
+
+    setItem(key, value) {
+        this.store[key] = String(value);
+    }
+
+    removeItem(key) {
+        delete this.store[key];
+    }
+}
+
+global.localStorage = new LocalStorageMock();
 
 jest.setTimeout(20_000);
 
@@ -34,3 +67,8 @@ jest.mock('./navigation/LinkingConfiguration.ts', () => {
 
 // Silence the warning: Animated: `useNativeDriver` is not supported because the native animated module is missing
 jest.mock('react-native/Libraries/Animated/src/NativeAnimatedHelper');
+
+// Set up MSW before all tests, close MSW after all tests and clear temporary listeners after each test.
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterAll(() => server.close());
+afterEach(() => server.resetHandlers());

--- a/packages/client/module.d.ts
+++ b/packages/client/module.d.ts
@@ -1,7 +1,9 @@
+type ApplicationEnvironment = 'development' | 'prod';
+
 declare global {
     namespace NodeJS {
         interface ProcessEnv {
-            NODE_ENV?: 'development' | 'prod';
+            NODE_ENV?: ApplicationEnvironment;
         }
     }
 }

--- a/packages/client/navigation/index.tsx
+++ b/packages/client/navigation/index.tsx
@@ -37,7 +37,10 @@ const Navigation: React.FC<ColorModeProps> = ({
 // Read more here: https://reactnavigation.org/docs/modal
 const Stack = createStackNavigator<RootStackParamList>();
 
-function RootNavigator({ toggleColorScheme, colorScheme }: ColorModeProps) {
+export const RootNavigator: React.FC<ColorModeProps> = ({
+    toggleColorScheme,
+    colorScheme,
+}) => {
     const style = navigationStyle(colorScheme);
 
     return (
@@ -78,6 +81,6 @@ function RootNavigator({ toggleColorScheme, colorScheme }: ColorModeProps) {
             </Stack.Screen>
         </Stack.Navigator>
     );
-}
+};
 
 export default Navigation;

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -11,7 +11,10 @@
     "build:tsc": "scripty",
     "lint": "yarn eslint . --ext ts,tsx --fix",
     "generate:xstate": "xstate-codegen machines/*.ts",
-    "postinstall": "expo-yarn-workspaces postinstall"
+    "postinstall": "expo-yarn-workspaces postinstall",
+    "test": "is-ci-cli \"test:coverage\" \"test:watch\"",
+    "test:coverage": "jest --coverage",
+    "test:watch": "jest --watch"
   },
   "jest": {
     "preset": "jest-expo"
@@ -58,11 +61,14 @@
     "@babel/core": "^7.9.0",
     "@expo/webpack-config": "^0.12.76",
     "@react-native-community/eslint-config": "^2.0.0",
+    "@testing-library/jest-native": "^4.0.1",
+    "@testing-library/react-native": "^7.2.0",
     "@types/react": "~17.0.8",
     "@types/react-native": "~0.64.8",
     "babel-plugin-inline-dotenv": "^1.6.0",
     "babel-plugin-transform-inline-environment-variables": "^0.4.3",
     "expo-yarn-workspaces": "^1.5.1",
+    "is-ci-cli": "^2.2.0",
     "jest-expo": "~41.0.0",
     "metro-config": "^0.59.0",
     "typescript": "^4.3.2"

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -2,6 +2,10 @@
   "name": "@musicroom/client",
   "version": "0.0.2",
   "main": "__generated__/AppEntry.js",
+  "volta": {
+    "node": "16.0.0",
+    "yarn": "1.22.10"
+  },
   "scripts": {
     "start": "expo start",
     "android": "expo start --android",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -63,14 +63,18 @@
     "@react-native-community/eslint-config": "^2.0.0",
     "@testing-library/jest-native": "^4.0.1",
     "@testing-library/react-native": "^7.2.0",
+    "@types/faker": "^5.5.6",
     "@types/react": "~17.0.8",
     "@types/react-native": "~0.64.8",
     "babel-plugin-inline-dotenv": "^1.6.0",
     "babel-plugin-transform-inline-environment-variables": "^0.4.3",
     "expo-yarn-workspaces": "^1.5.1",
+    "faker": "^5.5.3",
     "is-ci-cli": "^2.2.0",
     "jest-expo": "~41.0.0",
     "metro-config": "^0.59.0",
+    "msw": "^0.29.0",
+    "node-fetch": "^2.6.1",
     "typescript": "^4.3.2"
   },
   "scripty": {

--- a/packages/client/screens/ChatScreen.tsx
+++ b/packages/client/screens/ChatScreen.tsx
@@ -2,7 +2,7 @@ import { useMachine, useSelector } from '@xstate/react';
 import React from 'react';
 import { FlatList, StyleSheet, Text, TextInput, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { io } from 'socket.io-client';
+import { io } from '../services/websockets';
 import { assign, createMachine, send } from 'xstate';
 import { SERVER_ENDPOINT } from '../constants/Endpoints';
 import { SocketClient } from '../hooks/useSocket';

--- a/packages/client/services/__mocks__/websockets.ts
+++ b/packages/client/services/__mocks__/websockets.ts
@@ -1,0 +1,55 @@
+import {
+    AllClientToServerEvents,
+    AllServerToClientEvents,
+} from '@musicroom/types';
+import { Socket } from 'socket.io-client';
+
+let EVENTS: Record<string, ((...args: any) => void)[]> = {} as any;
+
+const socket = {
+    on<ServerToClientEvent extends keyof AllServerToClientEvents>(
+        event: ServerToClientEvent,
+        cb: (
+            ...args: Parameters<AllServerToClientEvents[ServerToClientEvent]>
+        ) => void,
+    ): void {
+        if (EVENTS[event]) {
+            EVENTS[event].push(cb);
+            return;
+        }
+        EVENTS[event] = [cb];
+    },
+    emit(): void {
+        return undefined;
+    },
+    disconnect(): void {
+        return undefined;
+    },
+};
+
+export const io: () => Socket<
+    AllServerToClientEvents,
+    AllClientToServerEvents
+> = () => socket as unknown as Socket;
+
+export const serverSocket = {
+    emit<Event extends keyof AllClientToServerEvents>(
+        event: Event,
+        ...args: Parameters<AllClientToServerEvents[Event]>
+    ): void {
+        const handlers = EVENTS[event];
+        if (handlers === undefined) {
+            return;
+        }
+
+        EVENTS[event].forEach((func) => {
+            func(...args);
+        });
+    },
+};
+
+export function cleanup(): void {
+    EVENTS = {};
+}
+
+export default io;

--- a/packages/client/services/websockets.ts
+++ b/packages/client/services/websockets.ts
@@ -1,0 +1,21 @@
+import { AllClientToServerEvents } from '@musicroom/types';
+
+export * from 'socket.io-client';
+
+/**
+ * ☢️ DO NOT USE OUTSIDE OF TESTS ☢️
+ *
+ * `serverSocket` must only be used in tests.
+ * It will be mocked, as well as `socket.io-client`, and will permit to simulate
+ * a bidirectional communication.
+ * @private
+ */
+export const serverSocket = {
+    emit<Event extends keyof AllClientToServerEvents>(
+        event: Event,
+        ...args: Parameters<AllClientToServerEvents[Event]>
+    ): void {
+        return undefined;
+    },
+};
+export type ServerSocket = typeof serverSocket;

--- a/packages/client/tests/global-mocks.ts
+++ b/packages/client/tests/global-mocks.ts
@@ -1,0 +1,34 @@
+import fetch from 'node-fetch';
+
+// @ts-expect-error The Fetch API is not available in Expo Jest environment (which is Node.js).
+// We use node-fetch polyfill and set the global reference to it.
+global.fetch = fetch;
+
+// MSW uses the LocalStorage internally. In order for MSW to work we need
+// to mock the LocalStorage API.
+class LocalStorageMock {
+    store: Record<string, unknown> = {};
+
+    constructor() {
+        this.store = {};
+    }
+
+    clear() {
+        this.store = {};
+    }
+
+    getItem(key: string) {
+        return this.store[key] || null;
+    }
+
+    setItem(key: string, value: unknown) {
+        this.store[key] = String(value);
+    }
+
+    removeItem(key: string) {
+        delete this.store[key];
+    }
+}
+
+// @ts-expect-error We need to mock localStorage API in Node.js for MSW to work
+global.localStorage = new LocalStorageMock();

--- a/packages/client/tests/server/handlers.ts
+++ b/packages/client/tests/server/handlers.ts
@@ -1,0 +1,25 @@
+import { rest } from 'msw';
+import faker from 'faker';
+
+import { SERVER_ENDPOINT } from '../../constants/Endpoints';
+import { SearchTracksAPIRawResponse } from '../../machines/searchTrackMachine';
+
+export const handlers = [
+    rest.get<undefined, SearchTracksAPIRawResponse, { query: string }>(
+        `${SERVER_ENDPOINT}/search/track/:query`,
+        (req, res, ctx) => {
+            const { query } = req.params;
+
+            return res(
+                ctx.json({
+                    videos: [
+                        {
+                            id: { videoId: faker.datatype.uuid() },
+                            snippet: { title: faker.random.words(3) },
+                        },
+                    ],
+                }),
+            );
+        },
+    ),
+];

--- a/packages/client/tests/server/test-server.ts
+++ b/packages/client/tests/server/test-server.ts
@@ -1,0 +1,8 @@
+import { setupServer } from 'msw/node';
+
+import { handlers } from './handlers';
+
+const server = setupServer(...handlers);
+
+export * from 'msw';
+export { server };

--- a/packages/client/tests/tests-utils.tsx
+++ b/packages/client/tests/tests-utils.tsx
@@ -1,14 +1,14 @@
+import React from 'react';
 import {
     RenderAPI,
     RenderOptions,
     render as rtlRender,
 } from '@testing-library/react-native';
 import { DripsyProvider } from 'dripsy';
-import React, { useState } from 'react';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
-import { colorPalette } from '../constants/Colors';
 import { MusicPlayerContextProvider } from '../contexts/MusicPlayerContext';
 import { useSocket } from '../hooks/useSocket';
+import { useTheme } from '../hooks/useTheme';
 import { ServerSocket, serverSocket } from '../services/websockets';
 
 export type SizeTerms = 'xs' | 's' | 'm' | 'l' | 'xl';
@@ -16,39 +16,7 @@ export type BackgroundTerms = 'primary' | 'seconday' | 'white' | 'text';
 
 const AllTheProviders: React.FC = ({ children }) => {
     const socket = useSocket();
-    const [colorScheme] = useState<'dark' | 'light'>('dark');
-    const palette = colorPalette(colorScheme);
-    const theme = {
-        colors: {
-            ...palette,
-        },
-        space: {
-            none: 0,
-            xs: 2,
-            s: 4,
-            m: 8,
-            l: 16,
-            xl: 24,
-        },
-        borderWidths: {
-            s: 1,
-            m: 2,
-            l: 3,
-        },
-        fontSizes: {
-            xs: 14,
-            s: 16,
-            m: 20,
-            l: 24,
-            xl: 32,
-        },
-        radii: {
-            s: 5,
-            m: 10,
-            l: 15,
-            full: 9999,
-        },
-    };
+    const { theme } = useTheme();
 
     return (
         <DripsyProvider theme={theme}>

--- a/packages/client/tests/tests-utils.tsx
+++ b/packages/client/tests/tests-utils.tsx
@@ -1,0 +1,84 @@
+import {
+    RenderAPI,
+    RenderOptions,
+    render as rtlRender,
+} from '@testing-library/react-native';
+import { DripsyProvider } from 'dripsy';
+import React, { useState } from 'react';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
+import { colorPalette } from '../constants/Colors';
+import { MusicPlayerContextProvider } from '../contexts/MusicPlayerContext';
+import { useSocket } from '../hooks/useSocket';
+import { ServerSocket, serverSocket } from '../services/websockets';
+
+export type SizeTerms = 'xs' | 's' | 'm' | 'l' | 'xl';
+export type BackgroundTerms = 'primary' | 'seconday' | 'white' | 'text';
+
+const AllTheProviders: React.FC = ({ children }) => {
+    const socket = useSocket();
+    const [colorScheme] = useState<'dark' | 'light'>('dark');
+    const palette = colorPalette(colorScheme);
+    const theme = {
+        colors: {
+            ...palette,
+        },
+        space: {
+            none: 0,
+            xs: 2,
+            s: 4,
+            m: 8,
+            l: 16,
+            xl: 24,
+        },
+        borderWidths: {
+            s: 1,
+            m: 2,
+            l: 3,
+        },
+        fontSizes: {
+            xs: 14,
+            s: 16,
+            m: 20,
+            l: 24,
+            xl: 32,
+        },
+        radii: {
+            s: 5,
+            m: 10,
+            l: 15,
+            full: 9999,
+        },
+    };
+
+    return (
+        <DripsyProvider theme={theme}>
+            <SafeAreaProvider
+                initialMetrics={{
+                    frame: { x: 0, y: 0, width: 0, height: 0 },
+                    insets: { top: 0, left: 0, right: 0, bottom: 0 },
+                }}
+            >
+                <MusicPlayerContextProvider socket={socket}>
+                    {children}
+                </MusicPlayerContextProvider>
+            </SafeAreaProvider>
+        </DripsyProvider>
+    );
+};
+
+export * from '@testing-library/react-native';
+
+export function render(
+    component: React.ReactElement<unknown>,
+    options?: RenderOptions,
+): RenderAPI & { serverSocket: ServerSocket } {
+    const utils = rtlRender(component, {
+        wrapper: AllTheProviders,
+        ...options,
+    });
+
+    return {
+        ...utils,
+        serverSocket,
+    };
+}

--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -9,5 +9,5 @@
         "declarationMap": true
     },
     "exclude": ["node_modules", "dist"],
-    "include": ["./jest.setup.ts", "tests", "./constants", "./machines"]
+    "include": ["./jest.setup.ts", "tests", "./constants", "./machines", "./hooks", "./services", "./contexts"]
 }

--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -8,5 +8,6 @@
         "emitDeclarationOnly": true,
         "declarationMap": true
     },
-    "exclude": ["node_modules", "dist"]
+    "exclude": ["node_modules", "dist"],
+    "include": ["./jest.setup.ts"]
 }

--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -9,5 +9,5 @@
         "declarationMap": true
     },
     "exclude": ["node_modules", "dist"],
-    "include": ["./jest.setup.ts"]
+    "include": ["./jest.setup.ts", "tests", "./constants", "./machines"]
 }

--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -9,5 +9,19 @@
         "declarationMap": true
     },
     "exclude": ["node_modules", "dist"],
-    "include": ["./jest.setup.ts", "tests", "./constants", "./machines", "./hooks", "./services", "./contexts"]
+    "include": [
+        "./jest.setup.ts",
+        "tests",
+        "./constants",
+        "./machines",
+        "./hooks",
+        "./services",
+        "./contexts",
+        "./navigation",
+        "./components",
+        "./screens",
+        "./App.tsx",
+        "./types.tsx",
+        "__tests__"
+    ]
 }

--- a/packages/server/app/Controllers/Http/TracksSearchesController.ts
+++ b/packages/server/app/Controllers/Http/TracksSearchesController.ts
@@ -8,11 +8,9 @@ const youtube = google.youtube({
 });
 
 export default class TracksSearchesController {
-    public async searchTrackName({
-        request,
-    }: HttpContextContract): Promise<
-        { videos: youtube_v3.Schema$SearchResult[] | undefined } | undefined
-    > {
+    public async searchTrackName({ request }: HttpContextContract): Promise<{
+        videos: youtube_v3.Schema$SearchResult[] | undefined;
+    }> {
         const params = request.params();
         const query = decodeURIComponent(params.query);
 

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -2,6 +2,10 @@
   "name": "server",
   "version": "1.0.0",
   "private": true,
+  "volta": {
+    "node": "16.0.0",
+    "yarn": "1.22.10"
+  },
   "scripts": {
     "build:tsc": "scripty",
     "build": "node ace dist --production",

--- a/packages/temporal/package.json
+++ b/packages/temporal/package.json
@@ -2,6 +2,10 @@
     "name": "@musicroom/temporal",
     "version": "0.0.1",
     "dependencies": {},
+    "volta": {
+        "node": "16.0.0",
+        "yarn": "1.22.10"
+    },
     "scripts": {
         "dev": "nodemon --exec env PORT=3000 ADONIS_ENDPOINT=`http://localhost:3333` go run api/main.go --signal SIGTERM",
         "worker": "env PORT=3000 ADONIS_ENDPOINT=http://localhost:3333 go run worker/main.go",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -4,6 +4,10 @@
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "volta": {
+    "node": "16.0.0",
+    "yarn": "1.22.10"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -4,6 +4,10 @@
   "main": "dist/index.js",
   "license": "MIT",
   "types": "dist/index.d.ts",
+  "volta": {
+    "node": "16.0.0",
+    "yarn": "1.22.10"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4082,6 +4082,25 @@
   dependencies:
     defer-to-connect "^2.0.0"
 
+"@testing-library/jest-native@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/jest-native/-/jest-native-4.0.1.tgz#000902622cb44f0d723a9f0e9eb8699f3ea511ae"
+  integrity sha512-dqeVpMSb8nZ1QxvzHxiKb4MqepNfFt8MeUwq9r/BTIOIrUFjDRDSpReZXVv9tcQypz2BcjbNK7BAEvyLSF33hQ==
+  dependencies:
+    chalk "^2.4.1"
+    jest-diff "^24.0.0"
+    jest-matcher-utils "^24.0.0"
+    pretty-format "^24.0.0"
+    ramda "^0.26.1"
+    redent "^2.0.0"
+
+"@testing-library/react-native@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-native/-/react-native-7.2.0.tgz#e5ec5b0974e4e5f525f8057563417d1e9f820d96"
+  integrity sha512-rDKzJjAAeGgyoJT0gFQiMsIL09chdWcwZyYx6WZHMgm2c5NDqY52hUuyTkzhqddMYWmSRklFphSg7B2HX+246Q==
+  dependencies:
+    pretty-format "^26.0.1"
+
 "@theme-ui/core@^0.4.0-rc.1":
   version "0.4.0-rc.13"
   resolved "https://registry.yarnpkg.com/@theme-ui/core/-/core-0.4.0-rc.13.tgz#ff206b3d2113f4f78df267d371ed21b03ac2da29"
@@ -8168,6 +8187,11 @@ dezalgo@^1.0.0:
     asap "^2.0.0"
     wrappy "1"
 
+diff-sequences@^24.9.0:
+  version "24.9.0"
+  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-24.9.0.tgz#5715d6244e2aa65f48bba0bc972db0b0b11e95b5"
+  integrity sha512-Dj6Wk3tWyTE+Fo1rW8v0Xhwk80um6yFYKbuAxc9c3EZxIHFDYwbi34Uk42u1CdnIiVorvt4RmlSDjIPyzGC2ew==
+
 diff-sequences@^25.2.6:
   version "25.2.6"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-25.2.6.tgz#5f467c00edd35352b7bca46d7927d60e687a76dd"
@@ -10984,6 +11008,11 @@ indent-string@^2.1.0:
   dependencies:
     repeating "^2.0.0"
 
+indent-string@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-3.2.0.tgz#4a5fd6d27cc332f37e5419a504dbb837105c9289"
+  integrity sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=
+
 indent-string@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-4.0.0.tgz#624f8f4497d619b2d9768531d58f4122854d7251"
@@ -11225,6 +11254,14 @@ is-callable@^1.1.4, is-callable@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.3.tgz#8b1e0500b73a1d76c70487636f368e519de8db8e"
   integrity sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==
+
+is-ci-cli@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/is-ci-cli/-/is-ci-cli-2.2.0.tgz#2cf6763f98413ff8a8409b400f85ac063e0c8a44"
+  integrity sha512-Xg97ZGDzU0a9gPTAli+TNegMk+PI3x0KLRYCfBa2LAboF1YyuA03Gwdc9vpu3VRNU+lFFNkvXnIQuJ0PgB120Q==
+  dependencies:
+    cross-spawn "^7.0.0"
+    is-ci "^2.0.0"
 
 is-ci@^2.0.0:
   version "2.0.0"
@@ -11863,6 +11900,16 @@ jest-config@^26.6.3:
     micromatch "^4.0.2"
     pretty-format "^26.6.2"
 
+jest-diff@^24.0.0, jest-diff@^24.9.0:
+  version "24.9.0"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-24.9.0.tgz#931b7d0d5778a1baf7452cb816e325e3724055da"
+  integrity sha512-qMfrTs8AdJE2iqrTp0hzh7kTd2PQWrsFyj9tORoKmu32xjPjeE4NyjVRDz8ybYwqS2ik8N4hsIpiVTyFeo2lBQ==
+  dependencies:
+    chalk "^2.0.1"
+    diff-sequences "^24.9.0"
+    jest-get-type "^24.9.0"
+    pretty-format "^24.9.0"
+
 jest-diff@^25.5.0:
   version "25.5.0"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-25.5.0.tgz#1dd26ed64f96667c068cef026b677dfa01afcfa9"
@@ -12119,6 +12166,16 @@ jest-leak-detector@^26.6.2:
   dependencies:
     jest-get-type "^26.3.0"
     pretty-format "^26.6.2"
+
+jest-matcher-utils@^24.0.0:
+  version "24.9.0"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-24.9.0.tgz#f5b3661d5e628dffe6dd65251dfdae0e87c3a073"
+  integrity sha512-OZz2IXsu6eaiMAwe67c1T+5tUAtQyQx27/EMEkbFAGiw52tB9em+uGbzpcgYVpA8wl0hlxKPZxrly4CXU/GjHA==
+  dependencies:
+    chalk "^2.0.1"
+    jest-diff "^24.9.0"
+    jest-get-type "^24.9.0"
+    pretty-format "^24.9.0"
 
 jest-matcher-utils@^25.5.0:
   version "25.5.0"
@@ -16136,7 +16193,7 @@ pretty-error@^2.1.1:
     lodash "^4.17.20"
     renderkid "^2.0.4"
 
-pretty-format@^24.9.0:
+pretty-format@^24.0.0, pretty-format@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-24.9.0.tgz#12fac31b37019a4eea3c11aa9a959eb7628aa7c9"
   integrity sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==
@@ -16156,7 +16213,7 @@ pretty-format@^25.1.0, pretty-format@^25.2.0, pretty-format@^25.5.0:
     ansi-styles "^4.0.0"
     react-is "^16.12.0"
 
-pretty-format@^26.0.0, pretty-format@^26.4.0, pretty-format@^26.6.2:
+pretty-format@^26.0.0, pretty-format@^26.0.1, pretty-format@^26.4.0, pretty-format@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-26.6.2.tgz#e35c2705f14cb7fe2fe94fa078345b444120fc93"
   integrity sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==
@@ -16454,6 +16511,11 @@ quick-lru@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-5.1.1.tgz#366493e6b3e42a3a6885e2e99d18f80fb7a8c932"
   integrity sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==
+
+ramda@^0.26.1:
+  version "0.26.1"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.26.1.tgz#8d41351eb8111c55353617fc3bbffad8e4d35d06"
+  integrity sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==
 
 random-bytes@~1.0.0:
   version "1.0.0"
@@ -16891,6 +16953,14 @@ redent@^1.0.0:
   dependencies:
     indent-string "^2.1.0"
     strip-indent "^1.0.1"
+
+redent@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/redent/-/redent-2.0.0.tgz#c1b2007b42d57eb1389079b3c8333639d5e1ccaa"
+  integrity sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=
+  dependencies:
+    indent-string "^3.0.0"
+    strip-indent "^2.0.0"
 
 redent@^3.0.0:
   version "3.0.0"
@@ -18441,6 +18511,11 @@ strip-indent@^1.0.1:
   integrity sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=
   dependencies:
     get-stdin "^4.0.1"
+
+strip-indent@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-2.0.0.tgz#5ef8db295d01e6ed6cbf7aab96998d7822527b68"
+  integrity sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=
 
 strip-indent@^3.0.0:
   version "3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3466,6 +3466,25 @@
     call-me-maybe "^1.0.1"
     glob-to-regexp "^0.3.0"
 
+"@mswjs/cookies@^0.1.5":
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/@mswjs/cookies/-/cookies-0.1.6.tgz#176f77034ab6d7373ae5c94bcbac36fee8869249"
+  integrity sha512-A53XD5TOfwhpqAmwKdPtg1dva5wrng2gH5xMvklzbd9WLTSVU953eCRa8rtrrm6G7Cy60BOGsBRN89YQK0mlKA==
+  dependencies:
+    "@types/set-cookie-parser" "^2.4.0"
+    set-cookie-parser "^2.4.6"
+
+"@mswjs/interceptors@^0.10.0":
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/@mswjs/interceptors/-/interceptors-0.10.0.tgz#f5aad03c2c0591d164e3ed178b21942f1c2f8061"
+  integrity sha512-/M0GGpid5q2EDI+Keas1sLYF3VZFXHDE5gCmX/jHdp+OJFruVNca3PUk7A8KnGdPpuycZogdPsmRBSOXwjyA7A==
+  dependencies:
+    "@open-draft/until" "^1.0.3"
+    debug "^4.3.0"
+    headers-utils "^3.0.2"
+    strict-event-emitter "^0.2.0"
+    xmldom "^0.6.0"
+
 "@nodelib/fs.scandir@2.1.4":
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz#d4b3549a5db5de2683e0c1071ab4f140904bbf69"
@@ -3655,6 +3674,11 @@
   integrity sha512-wWPSynU4oLy3i4KGyk+J1BLwRKyoeW2TwRHgwbDz17WtVFzSK2GOErGliruIx8c+MaYtHSYTx36DSmLNoNbtgA==
   dependencies:
     "@octokit/openapi-types" "^7.2.3"
+
+"@open-draft/until@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@open-draft/until/-/until-1.0.3.tgz#db9cc719191a62e7d9200f6e7bab21c5b848adca"
+  integrity sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q==
 
 "@phc/format@^1.0.0":
   version "1.0.0"
@@ -4215,6 +4239,11 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
   integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
 
+"@types/faker@^5.5.6":
+  version "5.5.6"
+  resolved "https://registry.yarnpkg.com/@types/faker/-/faker-5.5.6.tgz#039b700a9d8ad9150ecc842bf5e717e2027b6f75"
+  integrity sha512-UCRj0kLg4sXs2XFVm48OU/wIjyJZkpRkwxhRGVQb5l5GmemkeW22WTz9iiDhYPBUqTzDsIWzhFRuF/4DD5+q2Q==
+
 "@types/glob@^7.1.1":
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.3.tgz#e6ba80f36b7daad2c685acd9266382e68985c183"
@@ -4249,6 +4278,14 @@
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/http-cache-semantics/-/http-cache-semantics-4.0.0.tgz#9140779736aa2655635ee756e2467d787cfe8a2a"
   integrity sha512-c3Xy026kOF7QOTn00hbIllV1dLR9hG9NkSrLQgCVs8NF6sBU+VGWjD3wLPhmh1TYAc7ugCFsvHYMN4VcBN1U1A==
+
+"@types/inquirer@^7.3.1":
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/@types/inquirer/-/inquirer-7.3.1.tgz#1f231224e7df11ccfaf4cf9acbcc3b935fea292d"
+  integrity sha512-osD38QVIfcdgsPCT0V3lD7eH0OFurX71Jft18bZrsVQWVRt6TuxRzlr0GJLrxoHZR2V5ph7/qP8se/dcnI7o0g==
+  dependencies:
+    "@types/through" "*"
+    rxjs "^6.4.0"
 
 "@types/ioredis@^4.26.3":
   version "4.26.4"
@@ -4291,6 +4328,11 @@
   dependencies:
     jest-diff "^26.0.0"
     pretty-format "^26.0.0"
+
+"@types/js-levenshtein@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@types/js-levenshtein/-/js-levenshtein-1.1.0.tgz#9541eec4ad6e3ec5633270a3a2b55d981edc44a9"
+  integrity sha512-14t0v1ICYRtRVcHASzes0v/O+TIeASb8aD55cWF1PidtInhFWSXcmhzhHqGjUWf9SUq1w70cvd1cWKUULubAfQ==
 
 "@types/json-schema@^7.0.3", "@types/json-schema@^7.0.5", "@types/json-schema@^7.0.6", "@types/json-schema@^7.0.7":
   version "7.0.7"
@@ -4441,6 +4483,13 @@
   resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.1.tgz#18845205e86ff0038517aab7a18a62a6b9f71275"
   integrity sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA==
 
+"@types/set-cookie-parser@^2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@types/set-cookie-parser/-/set-cookie-parser-2.4.0.tgz#10cc0446bad372827671a5195fbd14ebce4a9baf"
+  integrity sha512-w7BFUq81sy7H/0jN0K5cax8MwRN6NOSURpY4YuO4+mOgoicxCZ33BUYz+gyF/sUf7uDl2We2yGJfppxzEXoAXQ==
+  dependencies:
+    "@types/node" "*"
+
 "@types/socket.io@^3.0.2":
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/@types/socket.io/-/socket.io-3.0.2.tgz#606c9639e3f93bb8454cba8f5f0a283d47917759"
@@ -4494,6 +4543,13 @@
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-1.0.7.tgz#545158342f949e8fd3bfd813224971ecddc3fac4"
   integrity sha512-0VBprVqfgFD7Ehb2vd8Lh9TG3jP98gvr8rgehQqzztZNI7o8zS8Ad4jyZneKELphpuE212D8J70LnSNQSyO6bQ==
+
+"@types/through@*":
+  version "0.0.30"
+  resolved "https://registry.yarnpkg.com/@types/through/-/through-0.0.30.tgz#e0e42ce77e897bd6aead6f6ea62aeb135b8a3895"
+  integrity sha512-FvnCJljyxhPM3gkRgWmxmDZyAQSiBQQWLI0A0VFL0K7W1oRUrPJSqNO0NvTnLkBcotdlp3lKvaT0JrnyRDkzOg==
+  dependencies:
+    "@types/node" "*"
 
 "@types/uglify-js@*":
   version "3.13.0"
@@ -6080,6 +6136,15 @@ bindings@^1.5.0:
   dependencies:
     file-uri-to-path "1.0.0"
 
+bl@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/bl/-/bl-4.1.0.tgz#451535264182bec2fbbc83a62ab98cf11d9f7b3a"
+  integrity sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==
+  dependencies:
+    buffer "^5.5.0"
+    inherits "^2.0.4"
+    readable-stream "^3.4.0"
+
 bluebird@^3.5.5:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
@@ -6327,7 +6392,7 @@ buffer@^4.3.0:
     ieee754 "^1.1.4"
     isarray "^1.0.0"
 
-buffer@^5.2.0:
+buffer@^5.2.0, buffer@^5.5.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0"
   integrity sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==
@@ -6726,7 +6791,7 @@ chokidar@^2.1.8:
   optionalDependencies:
     fsevents "^1.2.7"
 
-chokidar@^3.2.2, chokidar@^3.4.1, chokidar@^3.4.3, chokidar@^3.5.1:
+chokidar@^3.2.2, chokidar@^3.4.1, chokidar@^3.4.2, chokidar@^3.4.3, chokidar@^3.5.1:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.1.tgz#ee9ce7bbebd2b79f49f304799d5468e31e14e68a"
   integrity sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==
@@ -6845,7 +6910,7 @@ cli-highlight@^2.1.4:
     parse5-htmlparser2-tree-adapter "^6.0.0"
     yargs "^16.0.0"
 
-cli-spinners@^2.0.0:
+cli-spinners@^2.0.0, cli-spinners@^2.5.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-2.6.0.tgz#36c7dc98fb6a9a76bd6238ec3f77e2425627e939"
   integrity sha512-t+4/y50K/+4xcCRosKkA7W4gTr1MySvLV0q+PxmG7FJ5g+66ChKurYjxBCjHggHH3HA5Hh9cy+lcUGWDqVH+4Q==
@@ -7897,7 +7962,7 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0:
   dependencies:
     ms "2.0.0"
 
-debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@~4.3.1:
+debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.0, debug@^4.3.1, debug@~4.3.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
   integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
@@ -8982,7 +9047,7 @@ eventemitter3@^4.0.4:
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
   integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
 
-events@^3.0.0, events@^3.2.0:
+events@^3.0.0, events@^3.2.0, events@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
   integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
@@ -9319,6 +9384,11 @@ extsprintf@^1.2.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
+
+faker@^5.5.3:
+  version "5.5.3"
+  resolved "https://registry.yarnpkg.com/faker/-/faker-5.5.3.tgz#c57974ee484431b25205c2c8dc09fda861e51e0e"
+  integrity sha512-wLTv2a28wjUyWkbnX7u/ABZBkUkIF2fCd73V6P2oFqEGEktDfzWx4UxrSqtPRw0xPRAcjeAOIiJWqZm3pP4u3g==
 
 "falsey@^0.3.2":
   version "0.3.2"
@@ -10341,6 +10411,11 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.3
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.6.tgz#ff040b2b0853b23c3d31027523706f1885d76bee"
   integrity sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==
 
+graphql@^15.4.0:
+  version "15.5.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.5.0.tgz#39d19494dbe69d1ea719915b578bf920344a69d5"
+  integrity sha512-OmaM7y0kaK31NKG31q4YbD2beNYa6jBBKtMFT6gLYJljHLJr42IqJ8KX08u3Li/0ifzTU5HjmoOOrwa5BRLeDA==
+
 growly@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
@@ -10586,6 +10661,11 @@ header-case@^2.0.4:
   dependencies:
     capital-case "^1.0.4"
     tslib "^2.0.3"
+
+headers-utils@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/headers-utils/-/headers-utils-3.0.2.tgz#dfc65feae4b0e34357308aefbcafa99c895e59ef"
+  integrity sha512-xAxZkM1dRyGV2Ou5bzMxBPNLoRCjcX+ya7KSWybQD2KwLphxsapUVK6x/02o7f4VU6GPSXch9vNY2+gkU8tYWQ==
 
 helper-date@^1.0.1:
   version "1.0.1"
@@ -11131,6 +11211,26 @@ inquirer@^7.3.3:
     strip-ansi "^6.0.0"
     through "^2.3.6"
 
+inquirer@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-8.1.0.tgz#68ce5ce5376cf0e89765c993d8b7c1e62e184d69"
+  integrity sha512-1nKYPoalt1vMBfCMtpomsUc32wmOoWXAoq3kM/5iTfxyQ2f/BxjixQpC+mbZ7BI0JUXHED4/XPXekDVtJNpXYw==
+  dependencies:
+    ansi-escapes "^4.2.1"
+    chalk "^4.1.1"
+    cli-cursor "^3.1.0"
+    cli-width "^3.0.0"
+    external-editor "^3.0.3"
+    figures "^3.0.0"
+    lodash "^4.17.21"
+    mute-stream "0.0.8"
+    ora "^5.3.0"
+    run-async "^2.4.0"
+    rxjs "^6.6.6"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+    through "^2.3.6"
+
 internal-slot@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/internal-slot/-/internal-slot-1.0.3.tgz#7347e307deeea2faac2ac6205d4bc7d34967f59c"
@@ -11413,6 +11513,11 @@ is-installed-globally@^0.3.1:
   dependencies:
     global-dirs "^2.0.1"
     is-path-inside "^3.0.1"
+
+is-interactive@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-interactive/-/is-interactive-1.0.0.tgz#cea6e6ae5c870a7b0a0004070b7b587e0252912e"
+  integrity sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==
 
 is-lambda@^1.0.1:
   version "1.0.1"
@@ -12723,6 +12828,11 @@ jpeg-js@^0.4.0:
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/jpeg-js/-/jpeg-js-0.4.3.tgz#6158e09f1983ad773813704be80680550eff977b"
   integrity sha512-ru1HWKek8octvUHFHvE5ZzQ1yAsJmIvRdGWvSoKV52XKyuyYA437QWDttXT8eZXDSbuMpHlLzPDZUPd6idIz+Q==
+
+js-levenshtein@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/js-levenshtein/-/js-levenshtein-1.1.6.tgz#c6cee58eb3550372df8deb85fad5ce66ce01d59d"
+  integrity sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
@@ -14356,6 +14466,31 @@ ms@^2.0.0, ms@^2.1.1, ms@^2.1.2, ms@^2.1.3:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
+msw@^0.29.0:
+  version "0.29.0"
+  resolved "https://registry.yarnpkg.com/msw/-/msw-0.29.0.tgz#7242d575cb01db0c925241587df1fc2b79230d78"
+  integrity sha512-C/wz1d5uAEZRvAPAYrXG1rwLxXl0+BOs+JPrCzasoABZW3ATwS6ifSze+/DAgA93e9M86RXwvy6yDtZeZWmCFQ==
+  dependencies:
+    "@mswjs/cookies" "^0.1.5"
+    "@mswjs/interceptors" "^0.10.0"
+    "@open-draft/until" "^1.0.3"
+    "@types/cookie" "^0.4.0"
+    "@types/inquirer" "^7.3.1"
+    "@types/js-levenshtein" "^1.1.0"
+    chalk "^4.1.1"
+    chokidar "^3.4.2"
+    cookie "^0.4.1"
+    graphql "^15.4.0"
+    headers-utils "^3.0.2"
+    inquirer "^8.1.0"
+    js-levenshtein "^1.1.6"
+    node-fetch "^2.6.1"
+    node-match-path "^0.6.3"
+    statuses "^2.0.0"
+    strict-event-emitter "^0.2.0"
+    type-fest "^1.1.3"
+    yargs "^17.0.1"
+
 multimatch@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/multimatch/-/multimatch-5.0.0.tgz#932b800963cea7a31a033328fa1e0c3a1874dbe6"
@@ -14561,6 +14696,11 @@ node-libs-browser@^2.2.1:
     url "^0.11.0"
     util "^0.11.0"
     vm-browserify "^1.0.1"
+
+node-match-path@^0.6.3:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/node-match-path/-/node-match-path-0.6.3.tgz#55dd8443d547f066937a0752dce462ea7dc27551"
+  integrity sha512-fB1reOHKLRZCJMAka28hIxCwQLxGmd7WewOCBDYKpyA1KXi68A7vaGgdZAPhY2E6SXoYt3KqYCCvXLJ+O0Fu/Q==
 
 node-modules-regexp@^1.0.0:
   version "1.0.0"
@@ -15107,6 +15247,21 @@ ora@^3.4.0:
     cli-spinners "^2.0.0"
     log-symbols "^2.2.0"
     strip-ansi "^5.2.0"
+    wcwidth "^1.0.1"
+
+ora@^5.3.0:
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/ora/-/ora-5.4.1.tgz#1b2678426af4ac4a509008e5e4ac9e9959db9e18"
+  integrity sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==
+  dependencies:
+    bl "^4.1.0"
+    chalk "^4.1.0"
+    cli-cursor "^3.1.0"
+    cli-spinners "^2.5.0"
+    is-interactive "^1.0.0"
+    is-unicode-supported "^0.1.0"
+    log-symbols "^4.1.0"
+    strip-ansi "^6.0.0"
     wcwidth "^1.0.1"
 
 os-browserify@^0.3.0:
@@ -16877,7 +17032,7 @@ read@1, read@~1.0.1:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-readable-stream@3, readable-stream@^3.0.0, readable-stream@^3.0.2, readable-stream@^3.1.1, readable-stream@^3.6.0:
+readable-stream@3, readable-stream@^3.0.0, readable-stream@^3.0.2, readable-stream@^3.1.1, readable-stream@^3.4.0, readable-stream@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
   integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
@@ -17483,7 +17638,7 @@ rx-lite@*, rx-lite@^4.0.8:
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-4.0.8.tgz#0b1e11af8bc44836f04a6407e92da42467b79444"
   integrity sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=
 
-rxjs@^6.6.0, rxjs@^6.6.7:
+rxjs@^6.4.0, rxjs@^6.6.0, rxjs@^6.6.6, rxjs@^6.6.7:
   version "6.6.7"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.7.tgz#90ac018acabf491bf65044235d5863c4dab804c9"
   integrity sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==
@@ -17713,6 +17868,11 @@ set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
+
+set-cookie-parser@^2.4.6:
+  version "2.4.8"
+  resolved "https://registry.yarnpkg.com/set-cookie-parser/-/set-cookie-parser-2.4.8.tgz#d0da0ed388bc8f24e706a391f9c9e252a13c58b2"
+  integrity sha512-edRH8mBKEWNVIVMKejNnuJxleqYE/ZSdcT8/Nem9/mmosx12pctd80s2Oy00KNZzrogMZS5mauK2/ymL1bvlvg==
 
 set-getter@^0.1.0:
   version "0.1.0"
@@ -18262,6 +18422,11 @@ static-extend@^0.1.1:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
 
+statuses@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.1.tgz#55cb000ccf1d48728bd23c685a063998cf1a1b63"
+  integrity sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==
+
 std-env@^2.2.1:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/std-env/-/std-env-2.3.0.tgz#66d4a4a4d5224242ed8e43f5d65cfa9095216eee"
@@ -18310,6 +18475,13 @@ stream-shift@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.1.tgz#d7088281559ab2778424279b0877da3c392d5a3d"
   integrity sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==
+
+strict-event-emitter@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/strict-event-emitter/-/strict-event-emitter-0.2.0.tgz#78e2f75dc6ea502e5d8a877661065a1e2deedecd"
+  integrity sha512-zv7K2egoKwkQkZGEaH8m+i2D0XiKzx5jNsiSul6ja2IYFvil10A59Z9Y7PPAAe5OW53dQUf9CfsHKzjZzKkm1w==
+  dependencies:
+    events "^3.3.0"
 
 strict-uri-encode@^1.0.0:
   version "1.1.0"
@@ -19159,6 +19331,11 @@ type-fest@^0.8.0, type-fest@^0.8.1:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
+
+type-fest@^1.1.3:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-1.2.0.tgz#4cdf38ef9b047922c26038080cb269752ae359a2"
+  integrity sha512-++0N6KyAj0t2webXst0PE0xuXb4Dv3z1Z+4SGzK+j/epeWBZCfkQbkW/ezscZwpinmBQ5wu/l4TqagKSVcAGCA==
 
 type-is@^1.6.18:
   version "1.6.18"
@@ -20239,6 +20416,11 @@ xmldom@^0.5.0, xmldom@~0.5.0:
   resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.5.0.tgz#193cb96b84aa3486127ea6272c4596354cb4962e"
   integrity sha512-Foaj5FXVzgn7xFzsKeNIde9g6aFBxTPi37iwsno8QvApmtg7KYrr+OPyRHcJF7dud2a5nGRBXK3n0dL62Gf7PA==
 
+xmldom@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.6.0.tgz#43a96ecb8beece991cef382c08397d82d4d0c46f"
+  integrity sha512-iAcin401y58LckRZ0TkI4k0VSM1Qg0KGSc3i8rU+xrxe19A/BN1zHyVSJY7uoutVlaTSzYyk/v5AmkewAP7jtg==
+
 xpipe@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/xpipe/-/xpipe-1.0.5.tgz#8dd8bf45fc3f7f55f0e054b878f43a62614dafdf"
@@ -20401,6 +20583,19 @@ yargs@^16.0.0, yargs@^16.2.0:
   version "16.2.0"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-16.2.0.tgz#1c82bf0f6b6a66eafce7ef30e376f49a12477f66"
   integrity sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==
+  dependencies:
+    cliui "^7.0.2"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.0"
+    y18n "^5.0.5"
+    yargs-parser "^20.2.2"
+
+yargs@^17.0.1:
+  version "17.0.1"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.0.1.tgz#6a1ced4ed5ee0b388010ba9fd67af83b9362e0bb"
+  integrity sha512-xBBulfCc8Y6gLFcrPvtqKz9hz8SO0l1Ni8GgDekvBX2ro0HRQImDGnikfc33cgzcYUSncapnNcZDjVFIH3f6KQ==
   dependencies:
     cliui "^7.0.2"
     escalade "^3.1.1"


### PR DESCRIPTION
We set up Expo Jest, Testing Library React Native and MSW.
It was a bit difficult to set up MSW, as it is meant to be used with Jest inside a `JSDOM` environment. We had to mock the `Fetch` API and the `LocalStorage` API.

We wrote our first integration test, and we mocked `/search/track/:query` API route using MSW.

We listed all the directories containing TypeScript code inside the `tsconfig.json` file.

We set up volta on all the packages. Before the correct version was used only when we were in the top directory.