### PR TITLE
Connect Music Player to hardware back button

### DIFF
--- a/packages/client/components/TheMusicPlayer.tsx
+++ b/packages/client/components/TheMusicPlayer.tsx
@@ -1,10 +1,14 @@
 import { Ionicons } from '@expo/vector-icons';
 import Slider from '@react-native-community/slider';
+import { useFocusEffect } from '@react-navigation/native';
 import { useMachine } from '@xstate/react';
 import { format } from 'date-fns';
 import { enUS } from 'date-fns/locale';
 import { useSx, View } from 'dripsy';
 import React, { useMemo, useRef } from 'react';
+import { useEffect } from 'react';
+import { useCallback } from 'react';
+import { BackHandler } from 'react-native';
 import { TouchableOpacity, TouchableWithoutFeedback } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { assign, createMachine, Sender } from 'xstate';
@@ -482,6 +486,23 @@ const TheMusicPlayer: React.FC<TheMusicPlayerProps> = ({
             setIsFullScren(true);
         }
     }
+
+    useEffect(() => {
+        function onBackPress() {
+            if (isFullScreen) {
+                setIsFullScren(false);
+                return true;
+            }
+
+            return false;
+        }
+
+        BackHandler.addEventListener('hardwareBackPress', onBackPress);
+
+        return () => {
+            BackHandler.removeEventListener('hardwareBackPress', onBackPress);
+        };
+    }, [isFullScreen, setIsFullScren]);
 
     return (
         <TouchableWithoutFeedback onPress={openPlayerInFullScreen}>

--- a/packages/client/components/TheMusicPlayer.tsx
+++ b/packages/client/components/TheMusicPlayer.tsx
@@ -1,14 +1,11 @@
 import { Ionicons } from '@expo/vector-icons';
 import Slider from '@react-native-community/slider';
-import { useFocusEffect } from '@react-navigation/native';
+import { useBackHandler } from '@react-native-community/hooks';
 import { useMachine } from '@xstate/react';
 import { format } from 'date-fns';
 import { enUS } from 'date-fns/locale';
 import { useSx, View } from 'dripsy';
 import React, { useMemo, useRef } from 'react';
-import { useEffect } from 'react';
-import { useCallback } from 'react';
-import { BackHandler } from 'react-native';
 import { TouchableOpacity, TouchableWithoutFeedback } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { assign, createMachine, Sender } from 'xstate';
@@ -487,22 +484,14 @@ const TheMusicPlayer: React.FC<TheMusicPlayerProps> = ({
         }
     }
 
-    useEffect(() => {
-        function onBackPress() {
-            if (isFullScreen) {
-                setIsFullScren(false);
-                return true;
-            }
-
-            return false;
+    useBackHandler(() => {
+        if (isFullScreen) {
+            setIsFullScren(false);
+            return true;
         }
 
-        BackHandler.addEventListener('hardwareBackPress', onBackPress);
-
-        return () => {
-            BackHandler.removeEventListener('hardwareBackPress', onBackPress);
-        };
-    }, [isFullScreen, setIsFullScren]);
+        return false;
+    });
 
     return (
         <TouchableWithoutFeedback onPress={openPlayerInFullScreen}>

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@expo/vector-icons": "^12.0.5",
     "@musicroom/types": "*",
+    "@react-native-community/hooks": "^2.6.0",
     "@react-native-community/masked-view": "0.1.10",
     "@react-native-community/slider": "3.0.3",
     "@react-navigation/bottom-tabs": "5.11.11",


### PR DESCRIPTION
When the Music Player is in full screen mode and the hardware back button is pressed, we dismiss the Music Player.
We used [@react-native-community/hooks](https://github.com/react-native-community/hooks).

Closes #28 