### PR TITLE
Handle user joining in the state machine

### DIFF
--- a/packages/temporal/activities/mtv_controls.go
+++ b/packages/temporal/activities/mtv_controls.go
@@ -45,8 +45,18 @@ func CreationAcknowledgementActivity(_ context.Context, state shared.MtvRoomExpo
 	return err
 }
 
-func JoinActivity(ctx context.Context, state shared.MtvRoomExposedState) error {
-	marshaledBody, err := json.Marshal(state)
+type mtvJoinCallbackRequestBody struct {
+	State         shared.MtvRoomExposedState `json:"state"`
+	JoiningUserID string                     `json:"joiningUserID"`
+}
+
+func JoinActivity(ctx context.Context, state shared.MtvRoomExposedState, joiningUserID string) error {
+	requestBody := mtvJoinCallbackRequestBody{
+		State:         state,
+		JoiningUserID: joiningUserID,
+	}
+
+	marshaledBody, err := json.Marshal(requestBody)
 	if err != nil {
 		return err
 	}

--- a/packages/temporal/go.mod
+++ b/packages/temporal/go.mod
@@ -3,7 +3,7 @@ module github.com/AdonisEnProvence/MusicRoom
 go 1.16
 
 require (
-	github.com/Devessier/brainy v0.0.6
+	github.com/Devessier/brainy v0.0.9
 	github.com/bojanz/httpx v0.0.0-20201111190843-d1cf01c49b2e
 	github.com/bxcodec/faker/v3 v3.6.0
 	github.com/go-playground/universal-translator v0.17.0 // indirect

--- a/packages/temporal/go.sum
+++ b/packages/temporal/go.sum
@@ -1,8 +1,8 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/Devessier/brainy v0.0.6 h1:q/BxN30GsfjAvlj6VAP5+tj5Ql2Lh1sb7TWiy0axTMg=
-github.com/Devessier/brainy v0.0.6/go.mod h1:8tGYMsQmAbkw8Wv5wMJrHLEU02c494VX4Ys9nRFouJA=
+github.com/Devessier/brainy v0.0.9 h1:CsUtLTrgkAsMHYSyoeEAAPcYnUxBYO8oUIQgtvPsP9s=
+github.com/Devessier/brainy v0.0.9/go.mod h1:8tGYMsQmAbkw8Wv5wMJrHLEU02c494VX4Ys9nRFouJA=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/bojanz/httpx v0.0.0-20201111190843-d1cf01c49b2e h1:ta63AKr1LlBpEDB5zMk2uDgAdpkFpypfaywDvIp5PmI=
 github.com/bojanz/httpx v0.0.0-20201111190843-d1cf01c49b2e/go.mod h1:CmIVARSG6JaD9lvVI2Y0Jur5UvpndDJTcSOmgMdMqSQ=

--- a/packages/temporal/workflows/mtv.go
+++ b/packages/temporal/workflows/mtv.go
@@ -440,6 +440,7 @@ func MtvRoomWorkflow(ctx workflow.Context, params shared.MtvRoomParameters) erro
 								ctx,
 								activities.JoinActivity,
 								internalState.Export(),
+								event.UserID,
 							)
 
 							return nil

--- a/packages/temporal/workflows/mtv.go
+++ b/packages/temporal/workflows/mtv.go
@@ -100,7 +100,7 @@ func NewMtvRoomTimerExpirationEvent(t shared.MtvRoomTimer) MtvRoomTimerExpiratio
 	}
 }
 
-func InitialTracksFetchedEvent(tracks []shared.TrackMetadata) MtvRoomInitialTracksFetchedEvent {
+func NewMtvRoomInitialTracksFetchedEvent(tracks []shared.TrackMetadata) MtvRoomInitialTracksFetchedEvent {
 	return MtvRoomInitialTracksFetchedEvent{
 		EventWithType: brainy.EventWithType{
 			Event: MtvRoomInitialTracksFetched,
@@ -199,7 +199,6 @@ func MtvRoomWorkflow(ctx workflow.Context, params shared.MtvRoomParameters) erro
 						Actions: brainy.Actions{
 							brainy.ActionFn(
 								func(c brainy.Context, e brainy.Event) error {
-
 									event := e.(MtvRoomInitialTracksFetchedEvent)
 									internalState.Tracks = event.Tracks
 
@@ -214,6 +213,10 @@ func MtvRoomWorkflow(ctx workflow.Context, params shared.MtvRoomParameters) erro
 											internalState.Tracks = internalState.Tracks[1:]
 											internalState.TracksIDsList = internalState.TracksIDsList[1:]
 										}
+									}
+
+									if err := acknowledgeRoomCreation(ctx, internalState.Export()); err != nil {
+										workflowFatalError = err
 									}
 
 									return nil
@@ -535,12 +538,8 @@ func MtvRoomWorkflow(ctx workflow.Context, params shared.MtvRoomParameters) erro
 				}
 
 				internalState.Machine.Send(
-					InitialTracksFetchedEvent(initialTracksActivityResult),
+					NewMtvRoomInitialTracksFetchedEvent(initialTracksActivityResult),
 				)
-
-				if err := acknowledgeRoomCreation(ctx, internalState.Export()); err != nil {
-					workflowFatalError = err
-				}
 			})
 		}
 		/////

--- a/packages/temporal/workflows/mtv.go
+++ b/packages/temporal/workflows/mtv.go
@@ -32,7 +32,7 @@ func (s *MtvRoomInternalState) FillWith(params shared.MtvRoomParameters) {
 func (s *MtvRoomInternalState) Export() shared.MtvRoomExposedState {
 	isPlaying := false
 	if machine := s.Machine; machine != nil {
-		isPlaying = machine.Current().Matches(MtvRoomPlayingState)
+		isPlaying = machine.UnsafeCurrent().Matches(MtvRoomPlayingState)
 	}
 
 	exposedState := shared.MtvRoomExposedState{

--- a/packages/temporal/workflows/mtv_test.go
+++ b/packages/temporal/workflows/mtv_test.go
@@ -290,6 +290,7 @@ func (s *UnitTestSuite) Test_JoinCreatedRoom() {
 		activities.JoinActivity,
 		mock.Anything,
 		mock.Anything,
+		fakeUserID,
 	).Return(nil).Once()
 
 	s.env.RegisterDelayedCallback(func() {


### PR DESCRIPTION
We moved the code related to adding users in the room inside the state machine.

The `Export` method of `MtvRoomInternalState` type used to call the `Current` method of the state machine to gets its current state, and know if the room was playing. It caused deadlock when we tried to `Export` the internal state from an action of the state machine, as `Current` uses the lock of the state machine to prevent concurrent accesses. This security is unnecessary inside a workflow as all the code is guaranteed to run sequentially and on a single goroutine. Therefore we could replace the use of `Current` by its unsafe equivalent, `UnsafeCurrent`, which does not use the state machine lock.

Closes #60 