### PR TITLE
Forward go to next track action from the client to the mtv workflow and play the next track if applicable

### DIFF
--- a/packages/client/__tests__/ForcedDisconnectionPrintAlert.test.tsx
+++ b/packages/client/__tests__/ForcedDisconnectionPrintAlert.test.tsx
@@ -10,24 +10,8 @@ function noop() {
     return undefined;
 }
 
-function waitForTimeout(ms: number): Promise<void> {
-    return new Promise((resolve) => {
-        setTimeout(() => {
-            resolve();
-        }, ms);
-    });
-}
-
 test(`On FORCED_DISCONNECTION it should displays the alert modal and dismiss it when clicking on dismiss button`, async () => {
-    const {
-        getByText,
-        getByPlaceholderText,
-        getAllByText,
-        findByText,
-        getByTestId,
-        findByA11yState,
-        debug,
-    } = render(
+    const { getByText, getAllByText, findByText } = render(
         <NavigationContainer
             ref={navigationRef}
             onReady={() => {

--- a/packages/client/__tests__/GoToNextTrack.test.tsx
+++ b/packages/client/__tests__/GoToNextTrack.test.tsx
@@ -65,4 +65,6 @@ test(`When the user clicks on next track button, it should play the next track, 
         /play.*next.*track/i,
     );
     expect(nextTrackButton).toBeTruthy();
+
+    fireEvent.press(nextTrackButton);
 });

--- a/packages/client/__tests__/GoToNextTrack.test.tsx
+++ b/packages/client/__tests__/GoToNextTrack.test.tsx
@@ -1,0 +1,68 @@
+import { NavigationContainer } from '@react-navigation/native';
+import { datatype, random } from 'faker';
+import React from 'react';
+import { RootNavigator } from '../navigation';
+import { isReadyRef, navigationRef } from '../navigation/RootNavigation';
+import { serverSocket } from '../services/websockets';
+import { db } from '../tests/data';
+import { fireEvent, render, within } from '../tests/tests-utils';
+
+function noop() {
+    return undefined;
+}
+
+test(`When the user clicks on next track button, it should play the next track, if there is one`, async () => {
+    const tracksList = [db.tracksMetadata.create(), db.tracksMetadata.create()];
+
+    const { getAllByText, getByTestId, findByA11yState } = render(
+        <NavigationContainer
+            ref={navigationRef}
+            onReady={() => {
+                isReadyRef.current = true;
+            }}
+        >
+            <RootNavigator colorScheme="dark" toggleColorScheme={noop} />
+        </NavigationContainer>,
+    );
+
+    serverSocket.emit('RETRIEVE_CONTEXT', {
+        context: {
+            currentRoom: {
+                roomID: datatype.uuid(),
+                name: random.words(),
+            },
+            currentTrack: tracksList[0],
+            tracksList,
+
+            currentTrackDuration: 42,
+            currentTrackElapsedTime: 21,
+        },
+    });
+
+    /**
+     * Firstly expecting to be on the home
+     * And then click on GO TO MUSIC TRACK VOTE button
+     */
+    expect(getAllByText(/home/i).length).toBeGreaterThanOrEqual(1);
+
+    const musicPlayerMini = getByTestId('music-player-mini');
+    expect(musicPlayerMini).toBeTruthy();
+
+    const miniPlayerTrackTitle = await within(musicPlayerMini).findByText(
+        `${tracksList[0].title} • ${tracksList[0].artistName}`,
+    );
+    expect(miniPlayerTrackTitle).toBeTruthy();
+
+    fireEvent.press(miniPlayerTrackTitle);
+
+    const musicPlayerFullScreen = await findByA11yState({ expanded: true });
+    expect(musicPlayerFullScreen).toBeTruthy();
+    expect(
+        within(musicPlayerFullScreen).getByText(tracksList[0].title),
+    ).toBeTruthy();
+
+    const nextTrackButton = within(musicPlayerFullScreen).getByLabelText(
+        /play.*next.*track/i,
+    );
+    expect(nextTrackButton).toBeTruthy();
+});

--- a/packages/client/components/TheMusicPlayer/TheMusicPlayerFullScreen.tsx
+++ b/packages/client/components/TheMusicPlayer/TheMusicPlayerFullScreen.tsx
@@ -46,6 +46,7 @@ const TheMusicPlayerFullScreen: React.FC<TheMusicPlayerFullScreenProps> = ({
     }
 
     function handleNextTrackPress() {
+        // TODO: send an event to the state machine
         console.log('play next track');
     }
 

--- a/packages/client/components/TheMusicPlayer/TheMusicPlayerFullScreen.tsx
+++ b/packages/client/components/TheMusicPlayer/TheMusicPlayerFullScreen.tsx
@@ -46,8 +46,7 @@ const TheMusicPlayerFullScreen: React.FC<TheMusicPlayerFullScreenProps> = ({
     }
 
     function handleNextTrackPress() {
-        // TODO: send an event to the state machine
-        console.log('play next track');
+        sendToMachine('GO_TO_NEXT_TRACK');
     }
 
     return (

--- a/packages/client/components/TheMusicPlayer/TheMusicPlayerWithControls.tsx
+++ b/packages/client/components/TheMusicPlayer/TheMusicPlayerWithControls.tsx
@@ -105,6 +105,7 @@ const TheMusicPlayerWithControls: React.FC<TheMusicPlayerWithControlsProps> = ({
 
                 <MusicPlayerControlButton
                     iconName="play-forward"
+                    accessibilityLabel="Play next track"
                     onPress={onNextTrackPress}
                 />
             </View>

--- a/packages/client/machines/appMusicPlayerMachine.ts
+++ b/packages/client/machines/appMusicPlayerMachine.ts
@@ -151,9 +151,7 @@ export const createAppMusicPlayerMachine = ({
                             }
 
                             case 'GO_TO_NEXT_TRACK': {
-                                console.log(
-                                    '== GO TO NEXT TRACK IN WS SERVICE ==',
-                                );
+                                socket.emit('GO_TO_NEXT_TRACK');
 
                                 break;
                             }

--- a/packages/client/tests/data/index.ts
+++ b/packages/client/tests/data/index.ts
@@ -1,9 +1,16 @@
 import { factory, primaryKey } from '@mswjs/data';
-import { datatype, random } from 'faker';
+import { datatype, name, random } from 'faker';
 
 export const db = factory({
     tracks: {
         id: primaryKey(() => datatype.uuid()),
         title: () => random.words(3),
+    },
+
+    tracksMetadata: {
+        id: primaryKey(() => datatype.uuid()),
+        artistName: () => name.title(),
+        duration: () => 'PT4M52S' as string,
+        title: () => random.words(),
     },
 });

--- a/packages/server/app/Controllers/Http/Temporal/ServerToTemporalController.ts
+++ b/packages/server/app/Controllers/Http/Temporal/ServerToTemporalController.ts
@@ -21,6 +21,13 @@ interface TemporalCreateMtvWorkflowBody {
     initialTracksIDs: string[];
 }
 
+interface TemporalBaseArgs {
+    runID: string;
+    workflowID: string;
+}
+
+interface TemporalGoToNextTrackArgs extends TemporalBaseArgs {}
+
 export default class ServerToTemporalController {
     public static async createMtvWorkflow({
         workflowID,
@@ -137,5 +144,19 @@ export default class ServerToTemporalController {
         } catch (e) {
             throw new Error('Get State FAILED' + workflowID);
         }
+    }
+
+    public static async goToNextTrack({
+        workflowID,
+        runID,
+    }: TemporalGoToNextTrackArgs): Promise<void> {
+        const url = urlcat(TEMPORAL_ENDPOINT, '/go-to-next-track');
+
+        await got.put(url, {
+            json: {
+                workflowID,
+                runID,
+            },
+        });
     }
 }

--- a/packages/server/app/Controllers/Ws/MtvRoomsWsController.ts
+++ b/packages/server/app/Controllers/Ws/MtvRoomsWsController.ts
@@ -159,4 +159,15 @@ export default class MtvRoomsWsController {
         const room = await MtvRoom.findOrFail(roomID);
         return await ServerToTemporalController.getState(roomID, room.runID);
     }
+
+    public static async onGoToNextTrack({
+        payload: { roomID },
+    }: WsControllerMethodArgs<RoomID>): Promise<void> {
+        const { runID } = await MtvRoom.findOrFail(roomID);
+
+        await ServerToTemporalController.goToNextTrack({
+            workflowID: roomID,
+            runID,
+        });
+    }
 }

--- a/packages/server/start/socket.ts
+++ b/packages/server/start/socket.ts
@@ -140,6 +140,30 @@ Ws.io.on('connection', async (socket) => {
             }
         });
 
+        socket.on('GO_TO_NEXT_TRACK', async () => {
+            try {
+                const { mtvRoomID } =
+                    await SocketLifecycle.getSocketConnectionCredentials(
+                        socket,
+                    );
+
+                if (mtvRoomID === undefined) {
+                    throw new Error(
+                        'Can not go to the next track, the user is not listening to a mtv room',
+                    );
+                }
+
+                await MtvRoomsWsController.onGoToNextTrack({
+                    payload: {
+                        roomID: mtvRoomID,
+                    },
+                    socket,
+                });
+            } catch (err) {
+                console.error(err);
+            }
+        });
+
         socket.on('disconnecting', async () => {
             try {
                 await SocketLifecycle.checkForMtvRoomDeletion(socket);

--- a/packages/temporal/go.mod
+++ b/packages/temporal/go.mod
@@ -3,7 +3,7 @@ module github.com/AdonisEnProvence/MusicRoom
 go 1.16
 
 require (
-	github.com/Devessier/brainy v0.0.9
+	github.com/Devessier/brainy v0.0.10
 	github.com/bojanz/httpx v0.0.0-20201111190843-d1cf01c49b2e
 	github.com/bxcodec/faker/v3 v3.6.0
 	github.com/go-playground/universal-translator v0.17.0 // indirect

--- a/packages/temporal/go.sum
+++ b/packages/temporal/go.sum
@@ -1,8 +1,8 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/Devessier/brainy v0.0.9 h1:CsUtLTrgkAsMHYSyoeEAAPcYnUxBYO8oUIQgtvPsP9s=
-github.com/Devessier/brainy v0.0.9/go.mod h1:8tGYMsQmAbkw8Wv5wMJrHLEU02c494VX4Ys9nRFouJA=
+github.com/Devessier/brainy v0.0.10 h1:WtFkiyMXMdlSmltkfXwQEfLdLL/Z6yRBhL9aKqOwRso=
+github.com/Devessier/brainy v0.0.10/go.mod h1:8tGYMsQmAbkw8Wv5wMJrHLEU02c494VX4Ys9nRFouJA=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/bojanz/httpx v0.0.0-20201111190843-d1cf01c49b2e h1:ta63AKr1LlBpEDB5zMk2uDgAdpkFpypfaywDvIp5PmI=
 github.com/bojanz/httpx v0.0.0-20201111190843-d1cf01c49b2e/go.mod h1:CmIVARSG6JaD9lvVI2Y0Jur5UvpndDJTcSOmgMdMqSQ=

--- a/packages/temporal/shared/mtv.go
+++ b/packages/temporal/shared/mtv.go
@@ -65,10 +65,11 @@ type MtvRoomExposedState struct {
 type SignalRoute string
 
 const (
-	SignalRoutePlay      = "play"
-	SignalRoutePause     = "pause"
-	SignalRouteJoin      = "join"
-	SignalRouteTerminate = "terminate"
+	SignalRoutePlay          = "play"
+	SignalRoutePause         = "pause"
+	SignalRouteJoin          = "join"
+	SignalRouteTerminate     = "terminate"
+	SignalRouteGoToNextTrack = "go-to-next-track"
 )
 
 type GenericRouteSignal struct {
@@ -126,5 +127,15 @@ type NewTerminateSignalArgs struct{}
 func NewTerminateSignal(args NewTerminateSignalArgs) TerminateSignal {
 	return TerminateSignal{
 		Route: SignalRouteTerminate,
+	}
+}
+
+type GoToNextTrackSignal struct {
+	Route SignalRoute
+}
+
+func NewGoToNexTrackSignal() GoToNextTrackSignal {
+	return GoToNextTrackSignal{
+		Route: SignalRouteGoToNextTrack,
 	}
 }

--- a/packages/temporal/workflows/mtv.go
+++ b/packages/temporal/workflows/mtv.go
@@ -198,23 +198,10 @@ func MtvRoomWorkflow(ctx workflow.Context, params shared.MtvRoomParameters) erro
 
 						Actions: brainy.Actions{
 							brainy.ActionFn(
-								func(c brainy.Context, e brainy.Event) error {
-									event := e.(MtvRoomInitialTracksFetchedEvent)
-									internalState.Tracks = event.Tracks
-
-									if tracksCount := len(event.Tracks); tracksCount > 0 {
-										currentTrack := internalState.Tracks[0]
-										internalState.CurrentTrack = currentTrack
-
-										if tracksCount == 1 {
-											internalState.Tracks = []shared.TrackMetadata{}
-											internalState.TracksIDsList = []string{}
-										} else {
-											internalState.Tracks = internalState.Tracks[1:]
-											internalState.TracksIDsList = internalState.TracksIDsList[1:]
-										}
-									}
-
+								assignFetchedTracks(&internalState),
+							),
+							brainy.ActionFn(
+								func(brainy.Context, brainy.Event) error {
 									if err := acknowledgeRoomCreation(ctx, internalState.Export()); err != nil {
 										workflowFatalError = err
 									}
@@ -347,27 +334,7 @@ func MtvRoomWorkflow(ctx workflow.Context, params shared.MtvRoomParameters) erro
 
 									Actions: brainy.Actions{
 										brainy.ActionFn(
-											func(c brainy.Context, e brainy.Event) error {
-												ctx := c.(*MtvRoomMachineContext)
-
-												tracksCount := len(internalState.Tracks)
-												internalState.CurrentTrack = internalState.Tracks[0]
-												ctx.Timer = shared.MtvRoomTimer{
-													State:         shared.MtvRoomTimerStateIdle,
-													Elapsed:       0,
-													TotalDuration: internalState.CurrentTrack.Duration,
-												}
-
-												if tracksCount == 1 {
-													internalState.Tracks = []shared.TrackMetadata{}
-													internalState.TracksIDsList = []string{}
-												} else {
-													internalState.Tracks = internalState.Tracks[1:]
-													internalState.TracksIDsList = internalState.TracksIDsList[1:]
-												}
-
-												return nil
-											},
+											assignNextTrackIfAvailable(&internalState),
 										),
 									},
 								},

--- a/packages/temporal/workflows/mtv.go
+++ b/packages/temporal/workflows/mtv.go
@@ -170,7 +170,6 @@ func MtvRoomWorkflow(ctx workflow.Context, params shared.MtvRoomParameters) erro
 		Initial: MtvRoomFetchInitialTracks,
 
 		States: brainy.StateNodes{
-
 			MtvRoomFetchInitialTracks: &brainy.StateNode{
 				OnEntry: brainy.Actions{
 					brainy.ActionFn(

--- a/packages/temporal/workflows/mtv_actions.go
+++ b/packages/temporal/workflows/mtv_actions.go
@@ -1,0 +1,52 @@
+package workflows
+
+import (
+	"github.com/AdonisEnProvence/MusicRoom/shared"
+	"github.com/Devessier/brainy"
+)
+
+func assignFetchedTracks(internalState *MtvRoomInternalState) brainy.Action {
+	return func(c brainy.Context, e brainy.Event) error {
+		event := e.(MtvRoomInitialTracksFetchedEvent)
+		internalState.Tracks = event.Tracks
+
+		if tracksCount := len(event.Tracks); tracksCount > 0 {
+			currentTrack := internalState.Tracks[0]
+			internalState.CurrentTrack = currentTrack
+
+			if tracksCount == 1 {
+				internalState.Tracks = []shared.TrackMetadata{}
+				internalState.TracksIDsList = []string{}
+			} else {
+				internalState.Tracks = internalState.Tracks[1:]
+				internalState.TracksIDsList = internalState.TracksIDsList[1:]
+			}
+		}
+
+		return nil
+	}
+}
+
+func assignNextTrackIfAvailable(internalState *MtvRoomInternalState) brainy.Action {
+	return func(c brainy.Context, e brainy.Event) error {
+		ctx := c.(*MtvRoomMachineContext)
+
+		tracksCount := len(internalState.Tracks)
+		internalState.CurrentTrack = internalState.Tracks[0]
+		ctx.Timer = shared.MtvRoomTimer{
+			State:         shared.MtvRoomTimerStateIdle,
+			Elapsed:       0,
+			TotalDuration: internalState.CurrentTrack.Duration,
+		}
+
+		if tracksCount == 1 {
+			internalState.Tracks = []shared.TrackMetadata{}
+			internalState.TracksIDsList = []string{}
+		} else {
+			internalState.Tracks = internalState.Tracks[1:]
+			internalState.TracksIDsList = internalState.TracksIDsList[1:]
+		}
+
+		return nil
+	}
+}

--- a/packages/temporal/workflows/mtv_conds.go
+++ b/packages/temporal/workflows/mtv_conds.go
@@ -1,0 +1,11 @@
+package workflows
+
+import "github.com/Devessier/brainy"
+
+func hasNextTrackToPlay(internalState *MtvRoomInternalState) brainy.Cond {
+	return func(c brainy.Context, e brainy.Event) bool {
+		hasNextTrackToPlay := len(internalState.Tracks) > 0
+
+		return hasNextTrackToPlay
+	}
+}

--- a/packages/temporal/workflows/mtv_test.go
+++ b/packages/temporal/workflows/mtv_test.go
@@ -451,25 +451,6 @@ func (s *UnitTestSuite) Test_GoToNextTrack() {
 		s.env.SignalWorkflow(shared.SignalChannelName, goToNextTrackSignal)
 	}, firstGoToNextTrackSignal)
 
-	s.env.RegisterDelayedCallback(func() {
-		pauseSignal := shared.NewPauseSignal(shared.NewPauseSignalArgs{})
-
-		s.env.SignalWorkflow(shared.SignalChannelName, pauseSignal)
-	}, firstGoToNextTrackSignal+1*time.Millisecond)
-
-	// FIXME: debugging purposes
-	// s.env.RegisterDelayedCallback(func() {
-	// 	var mtvState shared.MtvRoomExposedState
-
-	// 	res, err := s.env.QueryWorkflow(shared.MtvGetStateQuery)
-	// 	s.NoError(err)
-
-	// 	err = res.Get(&mtvState)
-	// 	s.NoError(err)
-
-	// 	s.Equal(tracks[0], mtvState.CurrentTrack)
-	// }, firstGoToNextTrackSignal+1*time.Millisecond)
-
 	secondStateQueryAfterSecondTrackTotalDuration := firstGoToNextTrackSignal + secondTrackDuration
 	s.env.RegisterDelayedCallback(func() {
 		var mtvState shared.MtvRoomExposedState
@@ -483,45 +464,6 @@ func (s *UnitTestSuite) Test_GoToNextTrack() {
 		s.False(mtvState.Playing)
 		s.Equal(tracks[1], mtvState.CurrentTrack)
 	}, secondStateQueryAfterSecondTrackTotalDuration)
-
-	// // 6. We want to resume the first track.
-	// secondPlaySignalDelay := secondStateQueryAfterTotalTrackDuration + 1*time.Millisecond
-	// s.env.RegisterDelayedCallback(func() {
-	// 	playSignal := shared.NewPlaySignal(shared.NewPlaySignalArgs{})
-
-	// 	s.env.SignalWorkflow(shared.SignalChannelName, playSignal)
-	// }, secondPlaySignalDelay)
-
-	// // 7. We expect the first song and the second song to have finished.
-	// // While the second one is finished, we expect to still be the CurrentTrack.
-	// stateQueryAfterFirstTrackMustHaveFinished := secondPlaySignalDelay + firstTrackDuration
-	// s.env.RegisterDelayedCallback(func() {
-	// 	var mtvState shared.MtvRoomExposedState
-
-	// 	res, err := s.env.QueryWorkflow(shared.MtvGetStateQuery)
-	// 	s.NoError(err)
-
-	// 	err = res.Get(&mtvState)
-	// 	s.NoError(err)
-
-	// 	s.Equal(tracks[1], mtvState.CurrentTrack)
-	// }, stateQueryAfterFirstTrackMustHaveFinished)
-
-	// // 8.We expect the last track to remain the current one and the player
-	// // to be on paused state.
-	// stateQueryAfterAllTracksMustHaveFinished := stateQueryAfterFirstTrackMustHaveFinished + tracks[1].Duration
-	// s.env.RegisterDelayedCallback(func() {
-	// 	var mtvState shared.MtvRoomExposedState
-
-	// 	res, err := s.env.QueryWorkflow(shared.MtvGetStateQuery)
-	// 	s.NoError(err)
-
-	// 	err = res.Get(&mtvState)
-	// 	s.NoError(err)
-
-	// 	s.False(mtvState.Playing)
-	// 	s.Equal(tracks[1], mtvState.CurrentTrack)
-	// }, stateQueryAfterAllTracksMustHaveFinished)
 
 	s.env.ExecuteWorkflow(workflows.MtvRoomWorkflow, params)
 

--- a/packages/types/src/websockets.ts
+++ b/packages/types/src/websockets.ts
@@ -54,6 +54,7 @@ export interface RoomClientToServerEvents {
         callback: (payload: RoomServerToClientRetrieveContext) => void,
     ) => void;
     ACTION_PAUSE: () => void;
+    GO_TO_NEXT_TRACK: () => void;
 }
 
 export interface RoomServerToClientEvents {


### PR DESCRIPTION
When the go to next track button is pressed on the client, we send to the server a message through websockets. When the server receives it, it makes an HTTP call to the Temporal REST API. When the Temporal REST API receives the request, it sends a signal to the workflow of the mtv room.
When the mtv workflow receives the go to next track signal, it forwards the event to the state machine. Then, the state machine will transition to the playing state with the current track having been set to the next one, only if there are tracks to play.
These three parts have been tested.

Closes #62