### PR TITLE
Create a wrapper component to use different youtube client library on native and web paltforms

### DIFF
--- a/packages/client/components/TheMusicPlayer/Player.tsx
+++ b/packages/client/components/TheMusicPlayer/Player.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { Pressable, View } from 'react-native';
-import YoutubePlayer, { YoutubeIframeRef } from 'react-native-youtube-iframe';
+import YouTubePlayer, { PlayerRef } from '../YouTubePlayer';
 
-export type MusicPlayerRef = YoutubeIframeRef | null;
+export type MusicPlayerRef = PlayerRef | null;
 
 type MusicPlayerProps = {
     videoId: string;
@@ -23,18 +23,14 @@ const MusicPlayer: React.FC<MusicPlayerProps> = ({
     setPlayerRef,
     onTrackReady,
 }) => {
-    const playerRef = setPlayerRef as unknown as any;
-
     return (
         <Pressable onPress={noop} onLongPress={noop}>
             <View pointerEvents="none">
-                <YoutubePlayer
-                    ref={playerRef}
+                <YouTubePlayer
+                    ref={setPlayerRef}
                     height={playerHeight}
-                    play={videoState === 'playing'}
+                    playing={videoState === 'playing'}
                     videoId={videoId}
-                    //FIX for android see https://stackoverflow.com/questions/63171131/when-rendering-iframes-with-html-android-crashes-while-navigating-back-to-s
-                    webViewStyle={{ opacity: 0.99 }}
                     onReady={onTrackReady}
                 />
             </View>

--- a/packages/client/components/YouTubePlayer/contract.ts
+++ b/packages/client/components/YouTubePlayer/contract.ts
@@ -1,0 +1,18 @@
+import React from 'react';
+
+export interface PlayerProps {
+    height: number;
+    width?: number;
+    videoId: string;
+    playing: boolean;
+    onReady?: () => void;
+}
+
+export type PlayerComponent = React.ForwardRefExoticComponent<
+    PlayerProps & React.RefAttributes<PlayerRef>
+>;
+
+export interface PlayerRef {
+    getCurrentTime(): Promise<number>;
+    getDuration(): Promise<number>;
+}

--- a/packages/client/components/YouTubePlayer/index.tsx
+++ b/packages/client/components/YouTubePlayer/index.tsx
@@ -1,0 +1,12 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+import { Platform } from 'react-native';
+import { PlayerComponent } from './contract';
+
+const YouTubePlayer: PlayerComponent = Platform.select({
+    native: () => require('./native').default,
+    default: () => require('./web').default,
+})();
+
+export default YouTubePlayer;
+
+export * from './contract';

--- a/packages/client/components/YouTubePlayer/native.tsx
+++ b/packages/client/components/YouTubePlayer/native.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { useRef } from 'react';
+import { useImperativeHandle } from 'react';
+import { forwardRef } from 'react';
+import YoutubePlayer, { YoutubeIframeRef } from 'react-native-youtube-iframe';
+import { PlayerComponent, PlayerProps, PlayerRef } from './contract';
+
+const NativePlayer: PlayerComponent = forwardRef<PlayerRef, PlayerProps>(
+    ({ width, height, videoId, playing, onReady }, ref) => {
+        const playerRef = useRef<YoutubeIframeRef>(null);
+
+        useImperativeHandle(ref, () => ({
+            async getDuration() {
+                const duration = await playerRef.current?.getDuration();
+                if (duration === undefined) {
+                    throw new Error(
+                        'Could not get duration from react-native-youtube-iframe',
+                    );
+                }
+
+                return duration;
+            },
+
+            async getCurrentTime() {
+                const currentTime = await playerRef.current?.getCurrentTime();
+                if (currentTime === undefined) {
+                    throw new Error(
+                        'Could not get current time from react-native-youtube-iframe',
+                    );
+                }
+
+                return currentTime;
+            },
+        }));
+
+        return (
+            <YoutubePlayer
+                ref={playerRef}
+                videoId={videoId}
+                height={height}
+                width={width}
+                play={playing}
+                //FIX for android see https://stackoverflow.com/questions/63171131/when-rendering-iframes-with-html-android-crashes-while-navigating-back-to-s
+                webViewStyle={{ opacity: 0.99 }}
+                onReady={onReady}
+            />
+        );
+    },
+);
+
+export default NativePlayer;

--- a/packages/client/components/YouTubePlayer/web.tsx
+++ b/packages/client/components/YouTubePlayer/web.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { useRef } from 'react';
+import { useImperativeHandle } from 'react';
+import { useEffect } from 'react';
+import { forwardRef } from 'react';
+import YouTube, { Options } from 'react-youtube';
+import { PlayerComponent, PlayerProps, PlayerRef } from './contract';
+import { YoutubeIframePlayer } from './youtube-iframe';
+
+const WebPlayer: PlayerComponent = forwardRef<PlayerRef, PlayerProps>(
+    ({ width, height, videoId, playing, onReady }, ref) => {
+        const playerRef = useRef<YoutubeIframePlayer>();
+
+        useImperativeHandle(ref, () => ({
+            getDuration() {
+                const duration = playerRef.current?.getDuration();
+                if (duration === undefined) {
+                    throw new Error(
+                        'Could not get duration from react-youtube',
+                    );
+                }
+
+                return Promise.resolve(duration);
+            },
+
+            async getCurrentTime() {
+                const currentTime = playerRef.current?.getCurrentTime();
+                if (currentTime === undefined) {
+                    throw new Error(
+                        'Could not get current time from react-native-youtube-iframe',
+                    );
+                }
+
+                return Promise.resolve(currentTime);
+            },
+        }));
+
+        useEffect(() => {
+            if (playing === true) {
+                playerRef.current?.playVideo();
+            } else {
+                playerRef.current?.pauseVideo();
+            }
+        }, [playing, playerRef]);
+
+        const playerOptions: Options = {
+            height: String(height),
+            width: width !== undefined ? String(width) : '100%',
+        };
+
+        function setPlayerRef(ref: YouTube) {
+            if (ref === null) {
+                return;
+            }
+
+            playerRef.current = ref.getInternalPlayer() as YoutubeIframePlayer;
+        }
+
+        return (
+            <YouTube
+                ref={setPlayerRef}
+                videoId={videoId}
+                opts={playerOptions}
+                onReady={() => {
+                    onReady?.();
+                }}
+            />
+        );
+    },
+);
+
+export default WebPlayer;

--- a/packages/client/components/YouTubePlayer/web.tsx
+++ b/packages/client/components/YouTubePlayer/web.tsx
@@ -23,7 +23,7 @@ const WebPlayer: PlayerComponent = forwardRef<PlayerRef, PlayerProps>(
                 return Promise.resolve(duration);
             },
 
-            async getCurrentTime() {
+            getCurrentTime() {
                 const currentTime = playerRef.current?.getCurrentTime();
                 if (currentTime === undefined) {
                     throw new Error(

--- a/packages/client/components/YouTubePlayer/youtube-iframe.ts
+++ b/packages/client/components/YouTubePlayer/youtube-iframe.ts
@@ -1,0 +1,341 @@
+/**
+ * Copy pasted from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/youtube/index.d.ts
+ */
+export interface YoutubeIframePlayer {
+    //   /**
+    //    * Queues a video by ID.
+    //    *
+    //    * @param videoId   Video ID.
+    //    * @param startSeconds   Time from which the video should start playing.
+    //    * @param suggestedQuality   Suggested video player quality.
+    //    */
+    //   cueVideoById(
+    //     videoId: string,
+    //     startSeconds?: number,
+    //     suggestedQuality?: SuggestedVideoQuality
+    //   ): void;
+
+    //   /**
+    //    * Queues a video by ID.
+    //    *
+    //    * @param args   Settings to queue the video.
+    //    */
+    //   cueVideoById(args: VideoByIdSettings): void;
+
+    //   /**
+    //    * Loads and plays a video by ID.
+    //    *
+    //    * @param videoId   Video ID.
+    //    * @param startSeconds   Time from which the video should start playing.
+    //    * @param suggestedQuality   Suggested video player quality.
+    //    */
+    //   loadVideoById(
+    //     videoId: string,
+    //     startSeconds?: number,
+    //     suggestedQuality?: SuggestedVideoQuality
+    //   ): void;
+
+    //   /**
+    //    * Loads and plays a video by ID.
+    //    *
+    //    * @param args   Settings to play the video.
+    //    */
+    //   loadVideoById(args: VideoByIdSettings): void;
+
+    //   /**
+    //    * Queues a video by media content URL.
+    //    *
+    //    * @param mediaContentUrl   Fully qualified player URL.
+    //    * @param startSeconds   Time from which the video should start playing.
+    //    * @param suggestedQuality   Suggested video player quality.
+    //    */
+    //   cueVideoByUrl(
+    //     mediaContentUrl: string,
+    //     startSeconds?: number,
+    //     suggestedQuality?: SuggestedVideoQuality
+    //   ): void;
+
+    //   /**
+    //    * Queues a video by media content URL.
+    //    *
+    //    * @param args   Settings to play the video.
+    //    */
+    //   cueVideoByUrl(args: VideoByMediaContentUrlSettings): void;
+
+    //   /**
+    //    * Loads a video by media content URL.
+    //    *
+    //    * @param mediaContentUrl   Fully qualified player URL.
+    //    * @param startSeconds   Time from which the video should start playing.
+    //    * @param suggestedQuality   Suggested video player quality.
+    //    */
+    //   loadVideoByUrl(
+    //     mediaContentUrl: string,
+    //     startSeconds?: number,
+    //     suggestedQuality?: SuggestedVideoQuality
+    //   ): void;
+
+    //   /**
+    //    * Loads a video by media content URL.
+    //    *
+    //    * @param args   Settings to play the video.
+    //    */
+    //   loadVideoByUrl(args: {
+    //     mediaContentUrl: string;
+    //     startSeconds?: number | undefined;
+    //     endSeconds?: number | undefined;
+    //     suggestedQuality?: SuggestedVideoQuality | undefined;
+    //   }): void;
+
+    //   /**
+    //    * Queues a playlist of videos.
+    //    *
+    //    * @param playlist   Video ID(s) to play.
+    //    * @param index   Start index of the playlist, if not 0.
+    //    * @param startSeconds   Time from which the video should start playing.
+    //    * @param suggestedQuality   Suggested video player quality.
+    //    */
+    //   cuePlaylist(
+    //     playlist: string | string[],
+    //     index?: number,
+    //     startSeconds?: number,
+    //     suggestedQuality?: SuggestedVideoQuality
+    //   ): void;
+
+    //   /**
+    //    * Queues a playlist of videos.
+    //    *
+    //    * @param args   Settings to queue the playlist.
+    //    */
+    //   cuePlaylist(args: IPlaylistSettings): void;
+
+    //   /**
+    //    * Loads a playlist of videos.
+    //    *
+    //    * @param playlist   Video ID(s) to play.
+    //    * @param index   Start index of the playlist, if not 0.
+    //    * @param startSeconds   Time from which the video should start playing.
+    //    * @param suggestedQuality   Suggested video player quality.
+    //    */
+    //   loadPlaylist(
+    //     playlist: string | string[],
+    //     index?: number,
+    //     startSeconds?: number,
+    //     suggestedQuality?: SuggestedVideoQuality
+    //   ): void;
+
+    //   /**
+    //    * Loads a playlist of videos.
+    //    *
+    //    * @param args    Settings to queue the playlist.
+    //    */
+    //   loadPlaylist(args: IPlaylistSettings): void;
+
+    /**
+     * Plays the currently cued/loaded video.
+     */
+    playVideo(): void;
+
+    /**
+     * Pauses the currently playing video.
+     */
+    pauseVideo(): void;
+
+    /**
+     * Stops and cancels loading of the current video.
+     */
+    stopVideo(): void;
+
+    /**
+     * Seeks to a specified time in the video.
+     *
+     * @param seconds   Time, in seconds from the beginning of the video.
+     * @param allowSeekAhead   Whether the player is allowed to make a new request for unbuffered data.
+     */
+    seekTo(seconds: number, allowSeekAhead: boolean): void;
+
+    /**
+     * Loads and plays the next video in the playlist.
+     */
+    nextVideo(): void;
+
+    /**
+     * Loads and plays the previous video in the playlist.
+     */
+    previousVideo(): void;
+
+    /**
+     * Loads and plays the specified video in the playlist.
+     *
+     * @param index   Index of the video to play.
+     */
+    playVideoAt(index: number): void;
+
+    /**
+     * Mutes the player.
+     */
+    mute(): void;
+
+    /**
+     * Unmutes the player.
+     */
+    unMute(): void;
+
+    /**
+     * @returns Whether the player is muted.
+     */
+    isMuted(): boolean;
+
+    /**
+     * Sets the player volume.
+     *
+     * @param volume   An integer between 0 and 100.
+     */
+    setVolume(volume: number): void;
+
+    /**
+     * @returns The player's current volume, an integer between 0 and 100.
+     */
+    getVolume(): number;
+
+    /**
+     * Sets the size in pixels of the <iframe> that contains the player.
+     *
+     * @param width   Width in pixels of the <iframe>.
+     * @param height   Height in pixels of the <iframe>.
+     */
+    setSize(width: number, height: number): void;
+
+    /**
+     * @returns Playback rate of the currently playing video.
+     */
+    getPlaybackRate(): number;
+
+    /**
+     * Sets the suggested playback rate for the current video.
+     *
+     * @param suggestedRate   Suggested playback rate.
+     */
+    setPlaybackRate(suggestedRate: number): void;
+
+    /**
+     * @returns Available playback rates for the current video.
+     */
+    getAvailablePlaybackRates(): number[];
+
+    /**
+     * Sets whether the player should continuously play a playlist.
+     *
+     * @param loopPlaylists   Whether to continuously loop playlists.
+     */
+    setLoop(loopPlaylists: boolean): void;
+
+    /**
+     * Sets whether a playlist's videos should be shuffled.
+     *
+     * @param shufflePlaylist   Whether to shuffle playlist videos.
+     */
+    setShuffle(shufflePlaylist: boolean): void;
+
+    /**
+     * @returns A number between 0 and 1 of how much the player has buffered.
+     */
+    getVideoLoadedFraction(): number;
+
+    //   /**
+    //    * @returns Current player state.
+    //    */
+    //   getPlayerState(): PlayerState;
+
+    /**
+     * @returns Elapsed time in seconds since the video started playing.
+     */
+    getCurrentTime(): number;
+
+    //   /**
+    //    * @returns Actual video quality of the current video.
+    //    */
+    //   getPlaybackQuality(): SuggestedVideoQuality;
+
+    //   /**
+    //    * Sets the suggested video quality for the current video.
+    //    *
+    //    * @param suggestedQuality   Suggested video quality for the current video.
+    //    */
+    //   setPlaybackQuality(suggestedQuality: SuggestedVideoQuality): void;
+
+    //   /**
+    //    * @returns Quality formats in which the current video is available.
+    //    */
+    //   getAvailableQualityLevels(): SuggestedVideoQuality[];
+
+    /**
+     * @returns Duration in seconds of the currently playing video.
+     */
+    getDuration(): number;
+
+    /**
+     * @returns YouTube.com URL for the currently loaded/playing video.
+     */
+    getVideoUrl(): string;
+
+    //   /**
+    //    * @returns The spherical video config object, with information about the viewport
+    //    * headings and zoom level.
+    //    */
+    //   getSphericalProperties(): SphericalProperties;
+
+    //   /**
+    //    * Sets the spherical video config object. The call will be No-Op for non-360
+    //    * videos, and will change the view port according to the input for 360
+    //    * videos.
+    //    */
+    //   setSphericalProperties(option: SphericalProperties): void;
+
+    /**
+     * @returns Embed code for the currently loaded/playing video.
+     */
+    getVideoEmbedCode(): string;
+
+    /**
+     * @returns Video IDs in the playlist as they are currently ordered.
+     */
+    getPlaylist(): string[];
+
+    /**
+     * @returns Index of the playlist video that is currently playing.
+     */
+    getPlaylistIndex(): number;
+
+    //   /**
+    //    * Adds an event listener for the specified event.
+    //    *
+    //    * @param eventName   Name of the event.
+    //    * @param listener   Handler for the event.
+    //    */
+    //   addEventListener<TEvent extends PlayerEvent>(
+    //     eventName: keyof Events,
+    //     listener: (event: TEvent) => void
+    //   ): void;
+
+    //   /**
+    //    * Remove an event listener for the specified event.
+    //    *
+    //    * @param eventName   Name of the event.
+    //    * @param listener   Handler for the event.
+    //    */
+    //   removeEventListener<TEvent extends PlayerEvent>(
+    //     eventName: keyof Events,
+    //     listener: (event: TEvent) => void
+    //   ): void;
+
+    /**
+     * @returns The DOM node for the embedded <iframe>.
+     */
+    getIframe(): HTMLIFrameElement;
+
+    /**
+     * Removes the <iframe> containing the player.
+     */
+    destroy(): void;
+}

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -55,6 +55,7 @@
     "react-native-web-webview": "^1.0.2",
     "react-native-webview": "11.2.3",
     "react-native-youtube-iframe": "^2.1.0",
+    "react-youtube": "^7.13.1",
     "socket.io-client": "^4.1.2",
     "urlcat": "^2.0.4",
     "xstate": "^4.19.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8010,7 +8010,7 @@ dayjs@^1.8.15:
   resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.10.5.tgz#5600df4548fc2453b3f163ebb2abbe965ccfb986"
   integrity sha512-BUFis41ikLz+65iH6LHQCDm4YPMj5r1YFLdupPIyM4SGcXMmtiLQ7U37i+hGS8urIuqe7I/ou3IS1jVc4nbN4g==
 
-debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0:
+debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.6:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
@@ -9437,7 +9437,7 @@ fancy-log@^1.3.2:
     parse-node-version "^1.0.0"
     time-stamp "^1.0.0"
 
-fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
+fast-deep-equal@3.1.3, fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
@@ -13417,6 +13417,11 @@ load-json-file@^6.2.0:
     strip-bom "^4.0.0"
     type-fest "^0.6.0"
 
+load-script@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/load-script/-/load-script-1.0.0.tgz#0491939e0bee5643ee494a7e3da3d2bac70c6ca4"
+  integrity sha1-BJGTngvuVkPuSUp+PaPSuscMbKQ=
+
 loader-runner@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.4.0.tgz#ed47066bfe534d7e84c4c7b9998c2a75607d9357"
@@ -16697,7 +16702,7 @@ prop-ini@^0.0.2:
   dependencies:
     extend "^3.0.0"
 
-prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@15.7.2, prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -17123,6 +17128,15 @@ react-test-renderer@~16.11.0:
     prop-types "^15.6.2"
     react-is "^16.8.6"
     scheduler "^0.17.0"
+
+react-youtube@^7.13.1:
+  version "7.13.1"
+  resolved "https://registry.yarnpkg.com/react-youtube/-/react-youtube-7.13.1.tgz#3b327599a687bf22e071468818522920b36bcb57"
+  integrity sha512-b++TLHmHDpd0ZBS1wcbYabbuchU+W4jtx5A2MUQX0BINNKKsaIQX29sn/aLvZ9v5luwAoceia3VGtyz9blaB9w==
+  dependencies:
+    fast-deep-equal "3.1.3"
+    prop-types "15.7.2"
+    youtube-player "5.5.2"
 
 react@17.0.2:
   version "17.0.2"
@@ -18242,6 +18256,11 @@ sinon@^11.1.1:
     diff "^5.0.0"
     nise "^5.1.0"
     supports-color "^7.2.0"
+
+sister@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/sister/-/sister-3.0.2.tgz#bb3e39f07b1f75bbe1945f29a27ff1e5a2f26be4"
+  integrity sha512-p19rtTs+NksBRKW9qn0UhZ8/TUI9BPw9lmtHny+Y3TinWlOa9jWh9xB0AtPSdmOy49NJJJSSe0Ey4C7h0TrcYA==
 
 sisteransi@^1.0.5:
   version "1.0.5"
@@ -20885,6 +20904,15 @@ youch@^2.2.2:
     cookie "^0.4.1"
     mustache "^4.2.0"
     stack-trace "0.0.10"
+
+youtube-player@5.5.2:
+  version "5.5.2"
+  resolved "https://registry.yarnpkg.com/youtube-player/-/youtube-player-5.5.2.tgz#052b86b1eabe21ff331095ffffeae285fa7f7cb5"
+  integrity sha512-ZGtsemSpXnDky2AUYWgxjaopgB+shFHgXVpiJFeNB5nWEugpW1KWYDaHKuLqh2b67r24GtP6HoSW5swvf0fFIQ==
+  dependencies:
+    debug "^2.6.6"
+    load-script "^1.0.0"
+    sister "^3.0.0"
 
 z-schema@~3.18.3:
   version "3.18.4"


### PR DESCRIPTION
On native platforms we must use `react-native-youtube-iframe` library and on the Web we use `react-youtube`.

Thanks to React Native [platform specific code](https://reactnative.dev/docs/platform-specific-code), we load the correct library only when needed.

We used [Devessier/react-native-web-youtube-player](https://github.com/Devessier/react-native-web-youtube-player) as a playground.

Closes #39 