### PR TITLE
Fix broken search bar animations on Web

### DIFF
--- a/packages/client/components/kit/AppScreenHeaderSearchBar.tsx
+++ b/packages/client/components/kit/AppScreenHeaderSearchBar.tsx
@@ -1,5 +1,5 @@
 import { useMachine } from '@xstate/react';
-import React, { useEffect, useRef } from 'react';
+import React, { useRef } from 'react';
 import { TextInput as RNTextInput, TouchableOpacity } from 'react-native';
 import { createMachine } from 'xstate';
 import { View as MotiView } from 'moti';
@@ -8,6 +8,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { useLayout } from '../../hooks/useLayout';
 import Typo from './Typo';
 import TextInput from './TextInput';
+import { GLOBAL_THEME_CONSTANTS } from '../../hooks/useTheme';
 
 type AppScreenHeaderSearchBarProps = {
     searchInputPlaceholder: string;
@@ -83,7 +84,7 @@ const AppScreenHeaderSearchBar: React.FC<AppScreenHeaderSearchBarProps> = ({
     });
     const sx = useSx();
 
-    const cancelButtonLeftMargin = sx({ marginLeft: 'l' }).marginLeft as number;
+    const cancelButtonLeftMargin = GLOBAL_THEME_CONSTANTS.space.l;
 
     function blurTextInput() {
         textInputRef.current?.blur();

--- a/packages/client/components/kit/AppScreenHeaderWithSearchBar.tsx
+++ b/packages/client/components/kit/AppScreenHeaderWithSearchBar.tsx
@@ -8,6 +8,7 @@ import { useLayout } from '../../hooks/useLayout';
 import AppScreenHeaderSearchBar from './AppScreenHeaderSearchBar';
 import { AppScreenHeaderWithSearchBarMachineEvent } from '../../machines/appScreenHeaderWithSearchBarMachine';
 import { Sender } from '@xstate/react/lib/types';
+import { GLOBAL_THEME_CONSTANTS } from '../../hooks/useTheme';
 
 type AppScreenHeaderWithSearchBarPropsBase = {
     insetTop: number;
@@ -41,8 +42,7 @@ const AppScreenHeaderWithSearchBar: React.FC<AppScreenHeaderWithSearchBarProps> 
     }) => {
         const [{ height }, onLayout] = useLayout();
         const sx = useSx();
-        const titleMarginBottom = sx({ marginBottom: 'l' })
-            .marginBottom as number;
+        const titleMarginBottom = GLOBAL_THEME_CONSTANTS.space.l;
 
         useEffect(() => {
             setScreenOffsetY(-height - titleMarginBottom);

--- a/packages/client/hooks/useTheme.ts
+++ b/packages/client/hooks/useTheme.ts
@@ -10,6 +10,35 @@ interface UseThemeReturn {
     toggleColorScheme: () => void;
 }
 
+export const GLOBAL_THEME_CONSTANTS = {
+    space: {
+        none: 0,
+        xs: 2,
+        s: 4,
+        m: 8,
+        l: 16,
+        xl: 24,
+    },
+    borderWidths: {
+        s: 1,
+        m: 2,
+        l: 3,
+    },
+    fontSizes: {
+        xs: 14,
+        s: 16,
+        m: 20,
+        l: 24,
+        xl: 32,
+    },
+    radii: {
+        s: 5,
+        m: 10,
+        l: 15,
+        full: 9999,
+    },
+};
+
 export function useTheme(): UseThemeReturn {
     const [colorScheme, setColorScheme] = useState<ApplicationTheme>('dark');
     const palette = colorPalette(colorScheme);
@@ -17,32 +46,7 @@ export function useTheme(): UseThemeReturn {
         colors: {
             ...palette,
         },
-        space: {
-            none: 0,
-            xs: 2,
-            s: 4,
-            m: 8,
-            l: 16,
-            xl: 24,
-        },
-        borderWidths: {
-            s: 1,
-            m: 2,
-            l: 3,
-        },
-        fontSizes: {
-            xs: 14,
-            s: 16,
-            m: 20,
-            l: 24,
-            xl: 32,
-        },
-        radii: {
-            s: 5,
-            m: 10,
-            l: 15,
-            full: 9999,
-        },
+        ...GLOBAL_THEME_CONSTANTS,
     };
 
     const toggleColorScheme = () => {

--- a/packages/client/navigation/BottomBarNavigation.tsx
+++ b/packages/client/navigation/BottomBarNavigation.tsx
@@ -9,7 +9,7 @@ import {
     createBottomTabNavigator,
 } from '@react-navigation/bottom-tabs';
 import { createStackNavigator } from '@react-navigation/stack';
-import { Text, useSx, View } from 'dripsy';
+import { Text, useDripsyTheme, View } from 'dripsy';
 import React from 'react';
 import { TouchableOpacity } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -35,15 +35,16 @@ function MyTabBar({ state, descriptors, navigation }: BottomTabBarProps) {
     const { isFullScreen, setIsFullScreen } = useMusicPlayer();
 
     const insets = useSafeAreaInsets();
-    const sx = useSx();
+    const { theme } = useDripsyTheme();
     const focusedOptions = descriptors[state.routes[state.index].key].options;
 
     if (focusedOptions.tabBarVisible === false) {
         return null;
     }
 
-    const greyLighter = sx({ backgroundColor: 'greyLighter' })
-        .backgroundColor as string;
+    // greyLighter is not available on dripsy.ColorModesScale type
+    // but we add it to the theme on runtime.
+    const greyLighter = (theme.colors as any).greyLighter;
 
     return (
         <>


### PR DESCRIPTION
Animations of the search bar were broken on Web because [`sx` function from dripsy](https://github.com/nandorojo/dripsy#headless-dripsy-with-usesx) does not return an object with resolved values on the Web as it does on native platforms. The reason is that on the Web _react-native-web_ uses CSS Modules for styling. On the Web `sx` returns the id of the created CSS Module instead of an object with the styles.

As a consequence, we had to find a way to, nonetheless, get the values we wanted:

- We created an exported constant, `GLOBAL_THEME_CONSTANTS`, that contains some theme constants that do not differ between light and dark themes. This constant allows type checking without trying to change dripsy internal types.
- For values that are resolved at runtime, depending on the current theme, we use `useDripsyTheme` that returns the current theme. We can extract the property we want, here `greyLighter`, but we loose type safety.

Closes #67 