### PR TITLE
Fix initial track duration passed to the mtv workflow timer

### DIFF
--- a/packages/temporal/package.json
+++ b/packages/temporal/package.json
@@ -7,8 +7,8 @@
         "yarn": "1.22.10"
     },
     "scripts": {
-        "dev": "nodemon --signal SIGTERM --exec env PORT=3000 ADONIS_ENDPOINT='http://localhost:3333' go run api/main.go",
-        "worker": "nodemon --signal SIGTERM --exec godotenv -f ./.env env PORT=3000 ADONIS_ENDPOINT=http://localhost:3333 go run worker/main.go",
+        "dev": "nodemon --signal SIGTERM --ext go --exec env PORT=3000 ADONIS_ENDPOINT='http://localhost:3333' go run api/main.go",
+        "worker": "nodemon --signal SIGTERM --ext go --exec godotenv -f ./.env env PORT=3000 ADONIS_ENDPOINT='http://localhost:3333' go run worker/main.go",
         "temporal": "cd docker-compose && docker-compose up -d",
         "test": "go test ./..."
     },

--- a/packages/temporal/workflows/mtv_actions.go
+++ b/packages/temporal/workflows/mtv_actions.go
@@ -9,7 +9,9 @@ import (
 
 func assignFetchedTracks(internalState *MtvRoomInternalState) brainy.Action {
 	return func(c brainy.Context, e brainy.Event) error {
+		ctx := c.(*MtvRoomMachineContext)
 		event := e.(MtvRoomInitialTracksFetchedEvent)
+
 		internalState.Tracks = event.Tracks
 
 		if tracksCount := len(event.Tracks); tracksCount > 0 {
@@ -17,6 +19,11 @@ func assignFetchedTracks(internalState *MtvRoomInternalState) brainy.Action {
 			internalState.CurrentTrack = shared.CurrentTrack{
 				TrackMetadata: currentTrack,
 				Elapsed:       time.Second * 0,
+			}
+			ctx.Timer = shared.MtvRoomTimer{
+				State:         shared.MtvRoomTimerStateIdle,
+				Elapsed:       time.Second * 0,
+				TotalDuration: currentTrack.Duration,
 			}
 
 			if tracksCount == 1 {

--- a/packages/temporal/workflows/mtv_actions.go
+++ b/packages/temporal/workflows/mtv_actions.go
@@ -18,11 +18,11 @@ func assignFetchedTracks(internalState *MtvRoomInternalState) brainy.Action {
 			currentTrack := internalState.Tracks[0]
 			internalState.CurrentTrack = shared.CurrentTrack{
 				TrackMetadata: currentTrack,
-				Elapsed:       time.Second * 0,
+				Elapsed:       0,
 			}
 			ctx.Timer = shared.MtvRoomTimer{
 				State:         shared.MtvRoomTimerStateIdle,
-				Elapsed:       time.Second * 0,
+				Elapsed:       0,
 				TotalDuration: currentTrack.Duration,
 			}
 
@@ -32,6 +32,12 @@ func assignFetchedTracks(internalState *MtvRoomInternalState) brainy.Action {
 			} else {
 				internalState.Tracks = internalState.Tracks[1:]
 				internalState.TracksIDsList = internalState.TracksIDsList[1:]
+			}
+		} else {
+			ctx.Timer = shared.MtvRoomTimer{
+				State:         shared.MtvRoomTimerStateIdle,
+				Elapsed:       0,
+				TotalDuration: 0,
 			}
 		}
 

--- a/packages/temporal/workflows/mtv_test.go
+++ b/packages/temporal/workflows/mtv_test.go
@@ -129,6 +129,10 @@ func (s *UnitTestSuite) Test_PlayThenPauseTrack() {
 
 		switch trackTimerActivityCalls {
 		case 0:
+			s.Equal(shared.MtvRoomTimerStateIdle, timerState.State)
+			s.Equal(time.Duration(0), timerState.Elapsed)
+			s.Equal(firstTrackDuration, timerState.TotalDuration)
+
 			return shared.MtvRoomTimer{
 				State:         shared.MtvRoomTimerStatePending,
 				Elapsed:       firstTrackDurationFirstThird,
@@ -136,6 +140,10 @@ func (s *UnitTestSuite) Test_PlayThenPauseTrack() {
 			}, nil
 
 		case 1:
+			s.Equal(shared.MtvRoomTimerStatePending, timerState.State)
+			s.Equal(firstTrackDurationFirstThird, timerState.Elapsed)
+			s.Equal(firstTrackDuration, timerState.TotalDuration)
+
 			return shared.MtvRoomTimer{
 				State:         shared.MtvRoomTimerStateFinished,
 				Elapsed:       firstTrackDuration,
@@ -143,6 +151,10 @@ func (s *UnitTestSuite) Test_PlayThenPauseTrack() {
 			}, nil
 
 		case 2:
+			s.Equal(shared.MtvRoomTimerStateIdle, timerState.State)
+			s.Equal(time.Duration(0), timerState.Elapsed)
+			s.Equal(secondTrackDuration, timerState.TotalDuration)
+
 			return shared.MtvRoomTimer{
 				State:         shared.MtvRoomTimerStateFinished,
 				Elapsed:       secondTrackDuration,
@@ -455,6 +467,10 @@ func (s *UnitTestSuite) Test_GoToNextTrack() {
 
 		switch trackTimerActivityCalls {
 		case 0:
+			s.Equal(shared.MtvRoomTimerStateIdle, timerState.State)
+			s.Equal(time.Duration(0), timerState.Elapsed)
+			s.Equal(secondTrackDuration, timerState.TotalDuration)
+
 			return shared.MtvRoomTimer{
 				State:         shared.MtvRoomTimerStateFinished,
 				Elapsed:       secondTrackDuration,


### PR DESCRIPTION
The timer of the first initial track was not launched with correct parameters. It used to receive an empty duration when we were expecting to get the duration of the first track. It has been fixed.

We also told to nodemon to track all go files. There was an issue with the command of the worker, that nodemon could not parse correctly and then could not determine which files to track on its own.

Closes #70 