### PR TITLE
Hide properly full screen player when not on full screen mode

### DIFF
--- a/packages/client/components/TheMusicPlayer/TheMusicPlayerMini.tsx
+++ b/packages/client/components/TheMusicPlayer/TheMusicPlayerMini.tsx
@@ -72,9 +72,9 @@ const TheMusicPlayerMini: React.FC<TheMusicPlayerMiniProps> = ({
                 variant="normal"
                 adjustIconHorizontally={2}
                 disabled={!roomIsReady}
-                accessibilityLabel={`${
+                accessibilityLabel={
                     isPlaying ? 'Pause the video' : 'Play the video'
-                }`}
+                }
                 onPress={handlePlayPauseToggle}
             />
         </View>

--- a/packages/client/components/TheMusicPlayer/TheMusicPlayerWithControls.tsx
+++ b/packages/client/components/TheMusicPlayer/TheMusicPlayerWithControls.tsx
@@ -112,9 +112,9 @@ const TheMusicPlayerWithControls: React.FC<TheMusicPlayerWithControlsProps> = ({
                     variant="prominent"
                     adjustIconHorizontally={2}
                     disabled={controlDisabled}
-                    accessibilityLabel={`${
+                    accessibilityLabel={
                         isPlaying ? 'Pause the video' : 'Play the video'
-                    }`}
+                    }
                     onPress={onPlayingToggle}
                 />
 

--- a/packages/client/components/TheMusicPlayer/index.tsx
+++ b/packages/client/components/TheMusicPlayer/index.tsx
@@ -62,7 +62,9 @@ const TheMusicPlayer: React.FC<TheMusicPlayerProps> = ({
                         }}
                         style={{
                             flex: 1,
-                            transform: [{ translateY: isFullScreen ? 0 : 200 }],
+                            position: !isFullScreen ? 'absolute' : 'relative',
+                            bottom: !isFullScreen ? '100%' : undefined,
+                            right: !isFullScreen ? '100%' : undefined,
                         }}
                     >
                         <TheMusicPlayerFullScreen


### PR DESCRIPTION
The player was supposed to be hidden, but it was taking all its own height.
We had to position it absolutely outside the right bottom of the screen.

**There is currently an issue with the Web player: when it's size changes, the video is stopped. This issue will have to be fixed in the future because the player is also stopped when the player is reduced or maximized.**

Closes #82 