### PR TITLE
Load environment variables correctly in temporal package

### DIFF
--- a/packages/temporal/.env.example
+++ b/packages/temporal/.env.example
@@ -1,0 +1,3 @@
+GOOGLE_API_KEY=""
+PORT="3000"
+ADONIS_ENDPOINT="http://localhost:3333"

--- a/packages/temporal/package.json
+++ b/packages/temporal/package.json
@@ -8,12 +8,13 @@
         "yarn": "1.22.10"
     },
     "scripts": {
-        "dev": "nodemon --signal SIGTERM --ext go --exec env PORT=3000 ADONIS_ENDPOINT='http://localhost:3333' go run api/main.go",
-        "worker": "nodemon --signal SIGTERM --ext go --exec godotenv -f ./.env env PORT=3000 ADONIS_ENDPOINT='http://localhost:3333' go run worker/main.go",
+        "dev": "nodemon --signal SIGTERM --ext go --exec env-cmd go run api/main.go",
+        "worker": "nodemon --signal SIGTERM --ext go --exec env-cmd go run worker/main.go",
         "temporal": "cd docker-compose && docker-compose up -d",
         "test": "go test ./..."
     },
     "devDependencies": {
+        "env-cmd": "^10.1.0",
         "nodemon": "^2.0.7"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7186,7 +7186,7 @@ commander@^2.19.0, commander@^2.20.0, commander@^2.7.1:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
-commander@^4.1.1:
+commander@^4.0.0, commander@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
   integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
@@ -8667,6 +8667,14 @@ entities@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/entities/-/entities-2.2.0.tgz#098dc90ebb83d8dffa089d55256b351d34c4da55"
   integrity sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==
+
+env-cmd@^10.1.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/env-cmd/-/env-cmd-10.1.0.tgz#c7f5d3b550c9519f137fdac4dd8fb6866a8c8c4b"
+  integrity sha512-mMdWTT9XKN7yNth/6N6g2GuKuJTsKMDHlQFUDacb/heQRRWOTIZ42t1rMHnQu4jYxU1ajdTeJM+9eEETlqToMA==
+  dependencies:
+    commander "^4.0.0"
+    cross-spawn "^7.0.0"
 
 env-paths@^2.2.0:
   version "2.2.1"


### PR DESCRIPTION
We did not use dotenv as it only works with JavaScript programs. Instead we used [env-cmd](https://github.com/toddbluhm/env-cmd) that tries to load `.env` files and launches the provided command with the extracted environment variables.

Closes #90 