### PR TITLE
Forward suggestions from client to temporal

### DIFF
--- a/packages/client/__tests__/ForcedDisconnectionPrintAlert.test.tsx
+++ b/packages/client/__tests__/ForcedDisconnectionPrintAlert.test.tsx
@@ -33,7 +33,6 @@ test(`On FORCED_DISCONNECTION it should displays the alert modal and dismiss it 
             userID,
         },
         currentTrack: null,
-        tracksIDsList: null,
         roomCreatorUserID: userID,
         tracks: [
             {
@@ -41,6 +40,7 @@ test(`On FORCED_DISCONNECTION it should displays the alert modal and dismiss it 
                 artistName: name.findName(),
                 duration: 42000,
                 title: random.words(3),
+                score: datatype.number(),
             },
         ],
     });

--- a/packages/client/__tests__/ForcedDisconnectionPrintAlert.test.tsx
+++ b/packages/client/__tests__/ForcedDisconnectionPrintAlert.test.tsx
@@ -43,6 +43,7 @@ test(`On FORCED_DISCONNECTION it should displays the alert modal and dismiss it 
                 score: datatype.number(),
             },
         ],
+        suggestedTracks: null,
     });
 
     /**

--- a/packages/client/__tests__/GoToNextTrack.test.tsx
+++ b/packages/client/__tests__/GoToNextTrack.test.tsx
@@ -34,6 +34,7 @@ test(`When the user clicks on next track button, it should play the next track, 
             elapsed: 0,
         },
         tracks: tracksList.slice(1),
+        suggestedTracks: null,
     };
 
     serverSocket.on('GO_TO_NEXT_TRACK', () => {

--- a/packages/client/__tests__/GoToNextTrack.test.tsx
+++ b/packages/client/__tests__/GoToNextTrack.test.tsx
@@ -34,7 +34,6 @@ test(`When the user clicks on next track button, it should play the next track, 
             elapsed: 0,
         },
         tracks: tracksList.slice(1),
-        tracksIDsList: null,
     };
 
     serverSocket.on('GO_TO_NEXT_TRACK', () => {

--- a/packages/client/__tests__/SearchTrackScreen.test.tsx
+++ b/packages/client/__tests__/SearchTrackScreen.test.tsx
@@ -27,7 +27,6 @@ test(`Goes to Search a Track screen, searches a track, sees search results, pres
             emittingDeviceID: datatype.uuid(),
             userID,
         },
-        tracksIDsList: null,
         roomCreatorUserID: userID,
         currentTrack: {
             artistName: random.word(),
@@ -35,6 +34,7 @@ test(`Goes to Search a Track screen, searches a track, sees search results, pres
             duration: 158000,
             elapsed: 0,
             title: fakeTrack.title,
+            score: datatype.number(),
         },
         tracks: [
             {
@@ -42,6 +42,7 @@ test(`Goes to Search a Track screen, searches a track, sees search results, pres
                 artistName: name.findName(),
                 duration: 42000,
                 title: random.words(3),
+                score: datatype.number(),
             },
         ],
     };

--- a/packages/client/__tests__/SearchTrackScreen.test.tsx
+++ b/packages/client/__tests__/SearchTrackScreen.test.tsx
@@ -45,6 +45,7 @@ test(`Goes to Search a Track screen, searches a track, sees search results, pres
                 score: datatype.number(),
             },
         ],
+        suggestedTracks: null,
     };
 
     serverSocket.on('CREATE_ROOM', () => {

--- a/packages/client/__tests__/SessionRecover.test.tsx
+++ b/packages/client/__tests__/SessionRecover.test.tsx
@@ -44,6 +44,7 @@ test(`It should display the music player corresponding to the injected state on 
                 score: datatype.number(),
             },
         ],
+        suggestedTracks: null,
     };
 
     const { getAllByText, getByTestId, findByA11yState } = render(
@@ -139,6 +140,7 @@ test(`It should display the music player corresponding to the injected state on 
                 score: datatype.number(),
             },
         ],
+        suggestedTracks: null,
     };
 
     const { getAllByText, getByTestId, findByA11yState } = render(
@@ -220,6 +222,7 @@ test(`It should display the already elapsed track duration and player should be 
                 score: datatype.number(),
             },
         ],
+        suggestedTracks: null,
     };
 
     const { getAllByText, getByTestId, findByA11yState, debug } = render(

--- a/packages/client/__tests__/SessionRecover.test.tsx
+++ b/packages/client/__tests__/SessionRecover.test.tsx
@@ -26,7 +26,6 @@ test(`It should display the music player corresponding to the injected state on 
             emittingDeviceID: datatype.uuid(),
             userID,
         },
-        tracksIDsList: null,
         roomCreatorUserID: datatype.uuid(),
         currentTrack: {
             artistName: random.word(),
@@ -34,6 +33,7 @@ test(`It should display the music player corresponding to the injected state on 
             duration: 158000,
             elapsed: 0,
             title: fakeTrack.title,
+            score: datatype.number(),
         },
         tracks: [
             {
@@ -41,6 +41,7 @@ test(`It should display the music player corresponding to the injected state on 
                 artistName: name.findName(),
                 duration: 42000,
                 title: random.words(3),
+                score: datatype.number(),
             },
         ],
     };
@@ -120,7 +121,6 @@ test(`It should display the music player corresponding to the injected state on 
             emittingDeviceID: datatype.uuid(),
             userID,
         },
-        tracksIDsList: null,
         roomCreatorUserID: userID,
         currentTrack: {
             artistName: random.word(),
@@ -128,6 +128,7 @@ test(`It should display the music player corresponding to the injected state on 
             duration: 158000,
             elapsed: 0,
             title: fakeTrack.title,
+            score: datatype.number(),
         },
         tracks: [
             {
@@ -135,6 +136,7 @@ test(`It should display the music player corresponding to the injected state on 
                 artistName: name.findName(),
                 duration: 42000,
                 title: random.words(3),
+                score: datatype.number(),
             },
         ],
     };
@@ -200,7 +202,6 @@ test(`It should display the already elapsed track duration and player should be 
             emittingDeviceID: datatype.uuid(),
             userID,
         },
-        tracksIDsList: null,
         roomCreatorUserID: userID,
         currentTrack: {
             artistName: random.word(),
@@ -208,6 +209,7 @@ test(`It should display the already elapsed track duration and player should be 
             duration: 158000,
             elapsed: 100000,
             title: fakeTrack.title,
+            score: datatype.number(),
         },
         tracks: [
             {
@@ -215,6 +217,7 @@ test(`It should display the already elapsed track duration and player should be 
                 artistName: name.findName(),
                 duration: 42000,
                 title: random.words(3),
+                score: datatype.number(),
             },
         ],
     };

--- a/packages/client/__tests__/SuggestTrack.test.tsx
+++ b/packages/client/__tests__/SuggestTrack.test.tsx
@@ -78,6 +78,7 @@ test(`A user can suggest tracks to play`, async () => {
         ];
 
         serverSocket.emit('SUGGEST_TRACKS_CALLBACK', initialState);
+        serverSocket.emit('ACKNOWLEDGE_TRACKS_SUGGESTION');
     });
 
     const {

--- a/packages/client/__tests__/SuggestTrack.test.tsx
+++ b/packages/client/__tests__/SuggestTrack.test.tsx
@@ -35,7 +35,6 @@ test(`A user can suggest tracks to play`, async () => {
             elapsed: 0,
         },
         tracks: tracksList.slice(1),
-        tracksIDsList: null,
     };
 
     serverSocket.on('GO_TO_NEXT_TRACK', () => {

--- a/packages/client/__tests__/SuggestTrack.test.tsx
+++ b/packages/client/__tests__/SuggestTrack.test.tsx
@@ -54,6 +54,9 @@ test(`A user can suggest tracks to play`, async () => {
         serverSocket.emit('RETRIEVE_CONTEXT', initialState);
     });
 
+    const suggestTracksHandler = jest.fn();
+    serverSocket.on('SUGGEST_TRACKS', suggestTracksHandler);
+
     const {
         getAllByText,
         getByText,
@@ -122,6 +125,8 @@ test(`A user can suggest tracks to play`, async () => {
     fireEvent.press(trackToSuggest);
 
     await waitForElementToBeRemoved(() => getByText(/results/i));
+
+    expect(suggestTracksHandler).toHaveBeenCalledTimes(1);
 
     // TODO: decomment when it will have been implemented
     // const suggestedTrack = await within(musicPlayerFullScreen).findByText(

--- a/packages/client/__tests__/SuggestTrack.test.tsx
+++ b/packages/client/__tests__/SuggestTrack.test.tsx
@@ -77,8 +77,8 @@ test(`A user can suggest tracks to play`, async () => {
             }),
         ];
 
-        serverSocket.emit('SUGGEST_TRACKS_CALLBACK', initialState);
-        serverSocket.emit('ACKNOWLEDGE_TRACKS_SUGGESTION');
+        serverSocket.emit('SUGGESTED_TRACKS_LIST_UPDATE', initialState);
+        serverSocket.emit('SUGGEST_TRACKS_CALLBACK');
     });
 
     const {

--- a/packages/client/__tests__/UserDevices.test.tsx
+++ b/packages/client/__tests__/UserDevices.test.tsx
@@ -32,7 +32,6 @@ After clicking on one not emitting it should set the clicked one as emitting
             userID,
         },
         currentTrack: null,
-        tracksIDsList: null,
         roomCreatorUserID: userID,
         tracks: [
             {
@@ -40,6 +39,7 @@ After clicking on one not emitting it should set the clicked one as emitting
                 artistName: name.findName(),
                 duration: 42000,
                 title: random.words(3),
+                score: datatype.number(),
             },
         ],
     };

--- a/packages/client/__tests__/UserDevices.test.tsx
+++ b/packages/client/__tests__/UserDevices.test.tsx
@@ -1,4 +1,4 @@
-import { UserDevice } from '@musicroom/types';
+import { MtvWorkflowState, UserDevice } from '@musicroom/types';
 import { NavigationContainer } from '@react-navigation/native';
 import { datatype, name, random } from 'faker';
 import React from 'react';
@@ -22,7 +22,7 @@ After clicking on one not emitting it should set the clicked one as emitting
     }));
     const thisDevice = userDevices[0];
     const userID = datatype.uuid();
-    const state = {
+    const state: MtvWorkflowState = {
         roomID: datatype.uuid(),
         name: random.word(),
         playing: false,
@@ -42,6 +42,7 @@ After clicking on one not emitting it should set the clicked one as emitting
                 score: datatype.number(),
             },
         ],
+        suggestedTracks: null,
     };
 
     serverSocket.on('GET_CONNECTED_DEVICES_AND_DEVICE_ID', (cb) => {
@@ -55,7 +56,7 @@ After clicking on one not emitting it should set the clicked one as emitting
         serverSocket.emit('CHANGE_EMITTING_DEVICE_CALLBACK', {
             ...state,
             userRelatedInformation: {
-                ...state.userRelatedInformation,
+                ...state.userRelatedInformation!,
                 emittingDeviceID: newEmittingDeviceID,
             },
         });
@@ -105,7 +106,7 @@ After clicking on one not emitting it should set the clicked one as emitting
 
     userDevices.forEach((device) => {
         const isEmittingDevice =
-            state.userRelatedInformation.emittingDeviceID === device.deviceID;
+            state.userRelatedInformation?.emittingDeviceID === device.deviceID;
         let expectedDeviceName = device.name;
 
         if (isEmittingDevice) expectedDeviceName += ' EMITTING';

--- a/packages/client/__tests__/UserLeave.test.tsx
+++ b/packages/client/__tests__/UserLeave.test.tsx
@@ -1,10 +1,11 @@
-import { UserDevice } from '@musicroom/types';
+import { MtvWorkflowState, UserDevice } from '@musicroom/types';
 import { NavigationContainer } from '@react-navigation/native';
 import { datatype, name, random } from 'faker';
 import React from 'react';
 import { RootNavigator } from '../navigation';
 import { isReadyRef, navigationRef } from '../navigation/RootNavigation';
 import { serverSocket } from '../services/websockets';
+import { db } from '../tests/data';
 import { fireEvent, render, waitFor, within } from '../tests/tests-utils';
 
 function noop() {
@@ -21,7 +22,7 @@ He will be redirected to the home and will view the default mini music player
     }));
     const thisDevice = userDevices[0];
     const userID = datatype.uuid();
-    const state = {
+    const state: MtvWorkflowState = {
         roomID: datatype.uuid(),
         name: random.word(),
         playing: false,
@@ -31,16 +32,9 @@ He will be redirected to the home and will view the default mini music player
             userID,
         },
         currentTrack: null,
-        tracksIDsList: null,
         roomCreatorUserID: userID,
-        tracks: [
-            {
-                id: datatype.uuid(),
-                artistName: name.findName(),
-                duration: 42000,
-                title: random.words(3),
-            },
-        ],
+        tracks: [db.tracksMetadata.create()],
+        suggestedTracks: null,
     };
 
     let leaveRoomServerListenerHasBeenCalled = false;

--- a/packages/client/__tests__/UserLengthUpdate.test.tsx
+++ b/packages/client/__tests__/UserLengthUpdate.test.tsx
@@ -1,10 +1,11 @@
-import { UserDevice } from '@musicroom/types';
+import { MtvWorkflowState, UserDevice } from '@musicroom/types';
 import { NavigationContainer } from '@react-navigation/native';
 import { datatype, name, random } from 'faker';
 import React from 'react';
 import { RootNavigator } from '../navigation';
 import { isReadyRef, navigationRef } from '../navigation/RootNavigation';
 import { serverSocket } from '../services/websockets';
+import { db } from '../tests/data';
 import { fireEvent, render, within } from '../tests/tests-utils';
 
 function noop() {
@@ -21,7 +22,7 @@ test(`
     }));
     const thisDevice = userDevices[0];
     const userID = datatype.uuid();
-    const state = {
+    const state: MtvWorkflowState = {
         roomID: datatype.uuid(),
         name: random.word(),
         playing: false,
@@ -31,16 +32,9 @@ test(`
             userID,
         },
         currentTrack: null,
-        tracksIDsList: null,
         roomCreatorUserID: userID,
-        tracks: [
-            {
-                id: datatype.uuid(),
-                artistName: name.findName(),
-                duration: 42000,
-                title: random.words(3),
-            },
-        ],
+        tracks: [db.tracksMetadata.create()],
+        suggestedTracks: null,
     };
 
     const { debug, getByTestId, getAllByText, findByA11yState } = render(

--- a/packages/client/components/Track/TrackListItem.tsx
+++ b/packages/client/components/Track/TrackListItem.tsx
@@ -24,8 +24,6 @@ const TrackListItem: React.FC<TrackListItemProps> = ({
                 backgroundColor: 'greyLight',
                 borderRadius: 's',
                 flexDirection: 'row',
-
-                marginBottom: 'm',
             }}
         >
             <TouchableOpacity onPress={onPress} style={{ flex: 1 }}>

--- a/packages/client/contexts/MusicPlayerContext.tsx
+++ b/packages/client/contexts/MusicPlayerContext.tsx
@@ -148,10 +148,11 @@ export function useMusicPlayer(): MusicPlayerContextValue {
     return context;
 }
 
-export function useSuggestTracks(
-    closeSuggestionModal: () => void,
-): (tracksIDs: string[]) => void {
-    const { sendToMachine } = useMusicPlayer();
+export function useSuggestTracks(closeSuggestionModal: () => void): {
+    suggestTracks: (tracksIDs: string[]) => void;
+    showActivityIndicatorOnSuggestionsResultsScreen: boolean;
+} {
+    const { sendToMachine, state } = useMusicPlayer();
 
     function suggestTracks(tracksIDs: string[]) {
         sendToMachine({
@@ -161,5 +162,12 @@ export function useSuggestTracks(
         });
     }
 
-    return suggestTracks;
+    const showActivityIndicatorOnSuggestionsResultsScreen = state.hasTag(
+        'showActivityIndicatorOnSuggestionsResultsScreen',
+    );
+
+    return {
+        suggestTracks,
+        showActivityIndicatorOnSuggestionsResultsScreen,
+    };
 }

--- a/packages/client/contexts/MusicPlayerContext.tsx
+++ b/packages/client/contexts/MusicPlayerContext.tsx
@@ -152,8 +152,10 @@ export function useSuggestTracks(): (tracksIDs: string[]) => void {
     const { sendToMachine } = useMusicPlayer();
 
     function suggestTracks(tracksIDs: string[]) {
-        // TODO: send to the state machine the tracks the user wants to suggest
-        // sendToMachine()
+        sendToMachine({
+            type: 'SUGGEST_TRACKS',
+            tracksToSuggest: tracksIDs,
+        });
     }
 
     return suggestTracks;

--- a/packages/client/contexts/MusicPlayerContext.tsx
+++ b/packages/client/contexts/MusicPlayerContext.tsx
@@ -148,13 +148,16 @@ export function useMusicPlayer(): MusicPlayerContextValue {
     return context;
 }
 
-export function useSuggestTracks(): (tracksIDs: string[]) => void {
+export function useSuggestTracks(
+    closeSuggestionModal: () => void,
+): (tracksIDs: string[]) => void {
     const { sendToMachine } = useMusicPlayer();
 
     function suggestTracks(tracksIDs: string[]) {
         sendToMachine({
             type: 'SUGGEST_TRACKS',
             tracksToSuggest: tracksIDs,
+            closeSuggestionModal,
         });
     }
 

--- a/packages/client/contexts/MusicPlayerContext.tsx
+++ b/packages/client/contexts/MusicPlayerContext.tsx
@@ -1,6 +1,7 @@
 import { useMachine } from '@xstate/react';
 import React, { useContext, useRef } from 'react';
 import { Platform } from 'react-native';
+import Toast from 'react-native-toast-message';
 import { Sender } from 'xstate';
 import { MusicPlayerRef } from '../components/TheMusicPlayer/Player';
 import {
@@ -95,6 +96,14 @@ export const MusicPlayerContextProvider: React.FC<MusicPlayerContextProviderProp
                     navigateFromRef('HomeScreen');
                     navigateFromRef('Alert', {
                         reason: 'FORCED_DISCONNECTION',
+                    });
+                },
+
+                showTracksSuggestionAcknowledgementToast: () => {
+                    Toast.show({
+                        type: 'success',
+                        text1: 'Tracks suggestion',
+                        text2: 'Your suggestions have been accepted',
                     });
                 },
             },

--- a/packages/client/jest.setup.tsx
+++ b/packages/client/jest.setup.tsx
@@ -87,6 +87,11 @@ jest.mock('./navigation/LinkingConfiguration.ts', () => {
 // Silence the warning: Animated: `useNativeDriver` is not supported because the native animated module is missing
 jest.mock('react-native/Libraries/Animated/src/NativeAnimatedHelper');
 
+jest.mock('react-native-toast-message', () => ({
+    show: jest.fn(),
+    hide: jest.fn(),
+}));
+
 // Set up MSW before all tests, close MSW after all tests and clear temporary listeners after each test.
 beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
 afterAll(() => server.close());

--- a/packages/client/machines/appMusicPlayerMachine.ts
+++ b/packages/client/machines/appMusicPlayerMachine.ts
@@ -70,7 +70,6 @@ const rawContext: AppMusicPlayerMachineContext = {
     userRelatedInformation: null,
     usersLength: 0,
     currentTrack: null,
-    tracksIDsList: null,
     waitingRoomID: undefined,
     progressElapsedTime: 0,
 };

--- a/packages/client/machines/appMusicPlayerMachine.ts
+++ b/packages/client/machines/appMusicPlayerMachine.ts
@@ -574,11 +574,15 @@ export const createAppMusicPlayerMachine = ({
                                                         {
                                                             target: 'waitingForTracksToBeSuggested',
 
-                                                            actions: ({
-                                                                closeSuggestionModal,
-                                                            }) => {
-                                                                closeSuggestionModal?.();
-                                                            },
+                                                            actions: [
+                                                                ({
+                                                                    closeSuggestionModal,
+                                                                }) => {
+                                                                    closeSuggestionModal?.();
+                                                                },
+
+                                                                'showTracksSuggestionAcknowledgementToast',
+                                                            ],
                                                         },
                                                 },
                                             },

--- a/packages/client/machines/appMusicPlayerMachine.ts
+++ b/packages/client/machines/appMusicPlayerMachine.ts
@@ -55,7 +55,8 @@ export type AppMusicPlayerMachineEvent =
           state: MtvWorkflowState;
       }
     | { type: 'PAUSE_CALLBACK' }
-    | { type: 'SUGGEST_TRACKS'; tracksToSuggest: string[] };
+    | { type: 'SUGGEST_TRACKS'; tracksToSuggest: string[] }
+    | { type: 'SUGGEST_TRACKS_CALLBACK'; state: MtvWorkflowState };
 
 interface CreateAppMusicPlayerMachineArgs {
     socket: SocketClient;
@@ -87,7 +88,6 @@ export const createAppMusicPlayerMachine = ({
                 id: 'socketConnection',
                 src: (_context, _event) => (sendBack, onReceive) => {
                     socket.on('RETRIEVE_CONTEXT', (state) => {
-                        console.log('RETRIEVE_CONTEXT');
                         sendBack({
                             type: 'RETRIEVE_CONTEXT',
                             state,
@@ -103,9 +103,6 @@ export const createAppMusicPlayerMachine = ({
                     });
 
                     socket.on('CREATE_ROOM_SYNCHED_CALLBACK', (state) => {
-                        console.log('CREATE_ROOM_SYNCHED_CALLBACK recu', {
-                            state,
-                        });
                         sendBack({
                             type: 'JOINED_CREATED_ROOM',
                             state,
@@ -113,10 +110,6 @@ export const createAppMusicPlayerMachine = ({
                     });
 
                     socket.on('CHANGE_EMITTING_DEVICE_CALLBACK', (state) => {
-                        console.log('CHANGE_EMITTING_DEVICE_CALLBACK recu', {
-                            state,
-                        });
-
                         sendBack({
                             type: 'CHANGE_EMITTING_DEVICE_CALLBACK',
                             state,
@@ -124,7 +117,6 @@ export const createAppMusicPlayerMachine = ({
                     });
 
                     socket.on('CREATE_ROOM_CALLBACK', (state) => {
-                        console.log('CREATE_ROOM_CALLBACK recu', { state });
                         sendBack({
                             type: 'ROOM_IS_READY',
                             state,
@@ -139,7 +131,6 @@ export const createAppMusicPlayerMachine = ({
                     });
 
                     socket.on('ACTION_PLAY_CALLBACK', (state) => {
-                        console.log('ACTION_PLAY_CALLBACK', state);
                         sendBack({
                             type: 'PLAY_CALLBACK',
                             state,
@@ -152,8 +143,14 @@ export const createAppMusicPlayerMachine = ({
                         });
                     });
 
+                    socket.on('SUGGEST_TRACKS_CALLBACK', (state) => {
+                        sendBack({
+                            type: 'SUGGEST_TRACKS_CALLBACK',
+                            state,
+                        });
+                    });
+
                     socket.on('FORCED_DISCONNECTION', () => {
-                        console.log('RECEIVED FORCED DISCONNECTION');
                         sendBack({
                             type: 'FORCED_DISCONNECTION',
                         });
@@ -612,6 +609,10 @@ export const createAppMusicPlayerMachine = ({
                                     to: 'socketConnection',
                                 },
                             ),
+                        },
+
+                        SUGGEST_TRACKS_CALLBACK: {
+                            actions: 'assignMergeNewState',
                         },
                     },
                 },

--- a/packages/client/machines/appMusicPlayerMachine.ts
+++ b/packages/client/machines/appMusicPlayerMachine.ts
@@ -151,6 +151,10 @@ export const createAppMusicPlayerMachine = ({
                         });
                     });
 
+                    socket.on('ACKNOWLEDGE_TRACKS_SUGGESTION', () => {
+                        console.log('acknowledge tracks suggestion!');
+                    });
+
                     socket.on('FORCED_DISCONNECTION', () => {
                         sendBack({
                             type: 'FORCED_DISCONNECTION',

--- a/packages/client/machines/appMusicPlayerMachine.ts
+++ b/packages/client/machines/appMusicPlayerMachine.ts
@@ -68,6 +68,7 @@ const rawContext: AppMusicPlayerMachineContext = {
     roomCreatorUserID: '',
     roomID: '',
     tracks: null,
+    suggestedTracks: null,
     userRelatedInformation: null,
     usersLength: 0,
     currentTrack: null,

--- a/packages/client/machines/appMusicPlayerMachine.ts
+++ b/packages/client/machines/appMusicPlayerMachine.ts
@@ -629,7 +629,8 @@ export const createAppMusicPlayerMachine = ({
                         event.type !== 'ROOM_IS_READY' &&
                         event.type !== 'PLAY_CALLBACK' &&
                         event.type !== 'CHANGE_EMITTING_DEVICE_CALLBACK' &&
-                        event.type !== 'USER_LENGTH_UPDATE'
+                        event.type !== 'USER_LENGTH_UPDATE' &&
+                        event.type !== 'SUGGEST_TRACKS_CALLBACK'
                     ) {
                         return context;
                     }

--- a/packages/client/machines/appMusicPlayerMachine.ts
+++ b/packages/client/machines/appMusicPlayerMachine.ts
@@ -62,8 +62,8 @@ export type AppMusicPlayerMachineEvent =
           tracksToSuggest: string[];
           closeSuggestionModal: () => void;
       }
-    | { type: 'SUGGEST_TRACKS_CALLBACK'; state: MtvWorkflowState }
-    | { type: 'ACKNOWLEDGE_TRACKS_SUGGESTION' };
+    | { type: 'SUGGESTED_TRACKS_LIST_UPDATE'; state: MtvWorkflowState }
+    | { type: 'SUGGEST_TRACKS_CALLBACK' };
 
 interface CreateAppMusicPlayerMachineArgs {
     socket: SocketClient;
@@ -152,16 +152,16 @@ export const createAppMusicPlayerMachine = ({
                         });
                     });
 
-                    socket.on('SUGGEST_TRACKS_CALLBACK', (state) => {
+                    socket.on('SUGGESTED_TRACKS_LIST_UPDATE', (state) => {
                         sendBack({
-                            type: 'SUGGEST_TRACKS_CALLBACK',
+                            type: 'SUGGESTED_TRACKS_LIST_UPDATE',
                             state,
                         });
                     });
 
-                    socket.on('ACKNOWLEDGE_TRACKS_SUGGESTION', () => {
+                    socket.on('SUGGEST_TRACKS_CALLBACK', () => {
                         sendBack({
-                            type: 'ACKNOWLEDGE_TRACKS_SUGGESTION',
+                            type: 'SUGGEST_TRACKS_CALLBACK',
                         });
                     });
 
@@ -570,26 +570,25 @@ export const createAppMusicPlayerMachine = ({
                                                 ],
 
                                                 on: {
-                                                    ACKNOWLEDGE_TRACKS_SUGGESTION:
-                                                        {
-                                                            target: 'waitingForTracksToBeSuggested',
+                                                    SUGGEST_TRACKS_CALLBACK: {
+                                                        target: 'waitingForTracksToBeSuggested',
 
-                                                            actions: [
-                                                                ({
-                                                                    closeSuggestionModal,
-                                                                }) => {
-                                                                    closeSuggestionModal?.();
-                                                                },
+                                                        actions: [
+                                                            ({
+                                                                closeSuggestionModal,
+                                                            }) => {
+                                                                closeSuggestionModal?.();
+                                                            },
 
-                                                                'showTracksSuggestionAcknowledgementToast',
-                                                            ],
-                                                        },
+                                                            'showTracksSuggestionAcknowledgementToast',
+                                                        ],
+                                                    },
                                                 },
                                             },
                                     },
 
                                     on: {
-                                        SUGGEST_TRACKS_CALLBACK: {
+                                        SUGGESTED_TRACKS_LIST_UPDATE: {
                                             actions: 'assignMergeNewState',
                                         },
                                     },
@@ -721,7 +720,7 @@ export const createAppMusicPlayerMachine = ({
                         event.type !== 'PLAY_CALLBACK' &&
                         event.type !== 'CHANGE_EMITTING_DEVICE_CALLBACK' &&
                         event.type !== 'USER_LENGTH_UPDATE' &&
-                        event.type !== 'SUGGEST_TRACKS_CALLBACK'
+                        event.type !== 'SUGGESTED_TRACKS_LIST_UPDATE'
                     ) {
                         return context;
                     }

--- a/packages/client/machines/appMusicPlayerMachine.ts
+++ b/packages/client/machines/appMusicPlayerMachine.ts
@@ -54,7 +54,8 @@ export type AppMusicPlayerMachineEvent =
           type: 'RETRIEVE_CONTEXT';
           state: MtvWorkflowState;
       }
-    | { type: 'PAUSE_CALLBACK' };
+    | { type: 'PAUSE_CALLBACK' }
+    | { type: 'SUGGEST_TRACKS'; tracksToSuggest: string[] };
 
 interface CreateAppMusicPlayerMachineArgs {
     socket: SocketClient;
@@ -194,6 +195,17 @@ export const createAppMusicPlayerMachine = ({
                                 socket.emit('CHANGE_EMITTING_DEVICE', {
                                     newEmittingDeviceID: e.params.deviceID,
                                 });
+
+                                break;
+                            }
+
+                            case 'SUGGEST_TRACKS': {
+                                const tracksToSuggest = e.tracksToSuggest;
+
+                                socket.emit('SUGGEST_TRACKS', {
+                                    tracksToSuggest,
+                                });
+
                                 break;
                             }
                         }
@@ -589,6 +601,18 @@ export const createAppMusicPlayerMachine = ({
                         ROOM_IS_READY: {
                             target: '.creatingRoom.roomIsReady',
                             actions: 'assignMergeNewState',
+                        },
+
+                        SUGGEST_TRACKS: {
+                            actions: send(
+                                (_context, event) => ({
+                                    type: 'SUGGEST_TRACKS',
+                                    tracksToSuggest: event.tracksToSuggest,
+                                }),
+                                {
+                                    to: 'socketConnection',
+                                },
+                            ),
                         },
                     },
                 },

--- a/packages/client/machines/searchTrackMachine.ts
+++ b/packages/client/machines/searchTrackMachine.ts
@@ -1,23 +1,23 @@
 import urlcat from 'urlcat';
 import { createModel } from 'xstate/lib/model';
 import * as z from 'zod';
-import { TracksMetadata } from '@musicroom/types';
+import { TrackMetadata } from '@musicroom/types';
 import { SERVER_ENDPOINT } from '../constants/Endpoints';
 import { appScreenHeaderWithSearchBarMachine } from './appScreenHeaderWithSearchBarMachine';
 
 interface FetchTracksArgs {
     searchQuery: string;
-    tracks?: TracksMetadata[];
+    tracks?: TrackMetadata[];
 }
 
-export const SearchTracksAPIRawResponse = TracksMetadata.array().optional();
+export const SearchTracksAPIRawResponse = TrackMetadata.array().optional();
 export type SearchTracksAPIRawResponse = z.infer<
     typeof SearchTracksAPIRawResponse
 >;
 
 async function fetchTracks({
     searchQuery,
-}: FetchTracksArgs): Promise<TracksMetadata[] | undefined> {
+}: FetchTracksArgs): Promise<TrackMetadata[] | undefined> {
     const url = urlcat(SERVER_ENDPOINT, '/search/track/:searchQuery', {
         searchQuery,
     });
@@ -35,11 +35,11 @@ async function fetchTracks({
 
 const searchTrackModel = createModel(
     {
-        tracks: undefined as TracksMetadata[] | undefined,
+        tracks: undefined as TrackMetadata[] | undefined,
     },
     {
         events: {
-            FETCHED_TRACKS: (tracks: TracksMetadata[]) => ({ tracks }),
+            FETCHED_TRACKS: (tracks: TrackMetadata[]) => ({ tracks }),
             FAILED_FETCHING_TRACKS: () => ({}),
             SUBMITTED: (searchQuery: string) => ({ searchQuery }),
         },

--- a/packages/client/navigation/RootNavigation.tsx
+++ b/packages/client/navigation/RootNavigation.tsx
@@ -14,17 +14,6 @@ export const isReadyRef: React.MutableRefObject<boolean | null> =
 
 export const navigationRef = React.createRef<NavigationContainerRef>();
 
-export function useGlobalNavigationRef(): NavigationContainerRef | null {
-    const isReady = isReadyRef.current;
-    const navigation = navigationRef.current;
-
-    if (isReady === true && navigation !== null) {
-        return navigation;
-    }
-
-    return null;
-}
-
 // eslint-disable-next-line
 export function navigateFromRef<Route extends NavigateFromRefRoutes>(
     name: NavigateFromRefRoutes,

--- a/packages/client/navigation/RootNavigation.tsx
+++ b/packages/client/navigation/RootNavigation.tsx
@@ -14,6 +14,17 @@ export const isReadyRef: React.MutableRefObject<boolean | null> =
 
 export const navigationRef = React.createRef<NavigationContainerRef>();
 
+export function useGlobalNavigationRef(): NavigationContainerRef | null {
+    const isReady = isReadyRef.current;
+    const navigation = navigationRef.current;
+
+    if (isReady === true && navigation !== null) {
+        return navigation;
+    }
+
+    return null;
+}
+
 // eslint-disable-next-line
 export function navigateFromRef<Route extends NavigateFromRefRoutes>(
     name: NavigateFromRefRoutes,

--- a/packages/client/navigation/index.tsx
+++ b/packages/client/navigation/index.tsx
@@ -5,8 +5,8 @@
  */
 import { NavigationContainer } from '@react-navigation/native';
 import { createStackNavigator } from '@react-navigation/stack';
-import * as React from 'react';
-import { useEffect } from 'react';
+import React, { useEffect } from 'react';
+import Toast from 'react-native-toast-message';
 import { navigationStyle } from '../constants/Colors';
 import { AlertScreen } from '../screens/AlertScreen';
 import ChatScreen from '../screens/ChatScreen';
@@ -51,6 +51,8 @@ const Navigation: React.FC<ColorModeProps> = ({
                 colorScheme={colorScheme}
                 toggleColorScheme={toggleColorScheme}
             />
+
+            <Toast ref={(ref) => Toast.setRef(ref)} />
         </NavigationContainer>
     );
 };

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -53,6 +53,7 @@
     "react-native-reanimated": "~2.1.0",
     "react-native-safe-area-context": "3.2.0",
     "react-native-screens": "~3.0.0",
+    "react-native-toast-message": "^1.4.9",
     "react-native-web": "~0.16.3",
     "react-native-web-webview": "^1.0.2",
     "react-native-webview": "11.2.3",

--- a/packages/client/screens/HomeScreen.tsx
+++ b/packages/client/screens/HomeScreen.tsx
@@ -58,7 +58,7 @@ const HomeScreen: React.FC<HomeTabHomeScreenScreenProps> = ({ navigation }) => {
                             roomCreatorUserID: 'JUST A CREATOR ID',
                             roomID: 'JUST A ROOM ID',
                             tracks: null,
-                            tracksIDsList: null,
+                            suggestedTracks: null,
                             userRelatedInformation: {
                                 emittingDeviceID: 'EMITTING DEVICE',
                                 userID: 'JUST A USER ID',

--- a/packages/client/screens/SearchTrackResultsScreen.tsx
+++ b/packages/client/screens/SearchTrackResultsScreen.tsx
@@ -9,6 +9,7 @@ import { SearchTrackResultsScreenProps } from '../types';
 import { useMusicPlayer } from '../contexts/MusicPlayerContext';
 import { FlatList } from 'react-native';
 import TrackListItem from '../components/Track/TrackListItem';
+import { View } from 'dripsy';
 
 const SearchTracksResultsScreen: React.FC<SearchTrackResultsScreenProps> = ({
     route,
@@ -36,14 +37,20 @@ const SearchTracksResultsScreen: React.FC<SearchTrackResultsScreenProps> = ({
                         item: { id, title, artistName },
                         index,
                     }) => (
-                        <TrackListItem
-                            index={index + 1}
-                            title={title}
-                            artistName={artistName}
-                            onPress={() => {
-                                handleTrackPress(id);
+                        <View
+                            sx={{
+                                marginBottom: 'm',
                             }}
-                        />
+                        >
+                            <TrackListItem
+                                index={index + 1}
+                                title={title}
+                                artistName={artistName}
+                                onPress={() => {
+                                    handleTrackPress(id);
+                                }}
+                            />
+                        </View>
                     )}
                     keyExtractor={(_, index) => String(index)}
                 />

--- a/packages/client/screens/SuggestTrackResultsModal.tsx
+++ b/packages/client/screens/SuggestTrackResultsModal.tsx
@@ -17,12 +17,10 @@ const SuggestTrackResultsModal: React.FC<SearchTrackResultsScreenProps> = ({
 }) => {
     const tracks = route.params.tracks;
     const insets = useSafeAreaInsets();
-    const suggestTracks = useSuggestTracks();
+    const suggestTracks = useSuggestTracks(exitModal);
 
     function handleTrackPress(trackId: string) {
         suggestTracks([trackId]);
-
-        exitModal();
     }
 
     function handleGoBack() {

--- a/packages/client/screens/SuggestTrackResultsModal.tsx
+++ b/packages/client/screens/SuggestTrackResultsModal.tsx
@@ -9,6 +9,7 @@ import { SearchTrackResultsScreenProps } from '../types';
 import { FlatList } from 'react-native';
 import TrackListItem from '../components/Track/TrackListItem';
 import { useSuggestTracks } from '../contexts/MusicPlayerContext';
+import { View } from 'dripsy';
 
 const SuggestTrackResultsModal: React.FC<SearchTrackResultsScreenProps> = ({
     route,
@@ -49,14 +50,20 @@ const SuggestTrackResultsModal: React.FC<SearchTrackResultsScreenProps> = ({
                         item: { id, title, artistName },
                         index,
                     }) => (
-                        <TrackListItem
-                            index={index + 1}
-                            title={title}
-                            artistName={artistName}
-                            onPress={() => {
-                                handleTrackPress(id);
+                        <View
+                            sx={{
+                                marginBottom: 'm',
                             }}
-                        />
+                        >
+                            <TrackListItem
+                                index={index + 1}
+                                title={title}
+                                artistName={artistName}
+                                onPress={() => {
+                                    handleTrackPress(id);
+                                }}
+                            />
+                        </View>
                     )}
                     keyExtractor={(_, index) => String(index)}
                 />

--- a/packages/client/screens/SuggestTrackResultsModal.tsx
+++ b/packages/client/screens/SuggestTrackResultsModal.tsx
@@ -9,7 +9,7 @@ import { SearchTrackResultsScreenProps } from '../types';
 import { FlatList } from 'react-native';
 import TrackListItem from '../components/Track/TrackListItem';
 import { useSuggestTracks } from '../contexts/MusicPlayerContext';
-import { View } from 'dripsy';
+import { ActivityIndicator, View } from 'dripsy';
 
 const SuggestTrackResultsModal: React.FC<SearchTrackResultsScreenProps> = ({
     route,
@@ -17,7 +17,8 @@ const SuggestTrackResultsModal: React.FC<SearchTrackResultsScreenProps> = ({
 }) => {
     const tracks = route.params.tracks;
     const insets = useSafeAreaInsets();
-    const suggestTracks = useSuggestTracks(exitModal);
+    const { suggestTracks, showActivityIndicatorOnSuggestionsResultsScreen } =
+        useSuggestTracks(exitModal);
 
     function handleTrackPress(trackId: string) {
         suggestTracks([trackId]);
@@ -65,6 +66,23 @@ const SuggestTrackResultsModal: React.FC<SearchTrackResultsScreenProps> = ({
                     )}
                     keyExtractor={(_, index) => String(index)}
                 />
+
+                {showActivityIndicatorOnSuggestionsResultsScreen === true && (
+                    <View
+                        sx={{
+                            position: 'absolute',
+                            top: 0,
+                            left: 0,
+                            right: 0,
+                            bottom: 0,
+
+                            justifyContent: 'center',
+                            alignItems: 'center',
+                        }}
+                    >
+                        <ActivityIndicator size="large" />
+                    </View>
+                )}
             </AppScreenContainer>
         </AppScreen>
     );

--- a/packages/client/tests/data/index.ts
+++ b/packages/client/tests/data/index.ts
@@ -14,5 +14,6 @@ export const db = factory({
         artistName: () => name.title(),
         duration: () => 42000,
         title: () => random.words(),
+        score: () => datatype.number(),
     },
 });

--- a/packages/client/tests/data/index.ts
+++ b/packages/client/tests/data/index.ts
@@ -12,7 +12,15 @@ export const db = factory({
     tracksMetadata: {
         id: primaryKey(() => datatype.uuid()),
         artistName: () => name.title(),
-        duration: () => 42000,
+        duration: () => 42000 as number,
+        title: () => random.words(),
+        score: () => datatype.number(),
+    },
+
+    suggestedTracksMetadata: {
+        id: primaryKey(() => datatype.uuid()),
+        artistName: () => name.title(),
+        duration: () => 42000 as number,
         title: () => random.words(),
         score: () => datatype.number(),
     },

--- a/packages/client/tests/server/handlers.ts
+++ b/packages/client/tests/server/handlers.ts
@@ -1,5 +1,5 @@
 import { rest } from 'msw';
-import { TracksMetadata } from '@musicroom/types';
+import { TrackMetadata } from '@musicroom/types';
 
 import { SERVER_ENDPOINT } from '../../constants/Endpoints';
 import { SearchTracksAPIRawResponse } from '../../machines/searchTrackMachine';
@@ -19,7 +19,7 @@ export const handlers = [
                 },
             });
 
-            return res(ctx.json(tracks as TracksMetadata[] | undefined));
+            return res(ctx.json(tracks as TrackMetadata[] | undefined));
         },
     ),
 ];

--- a/packages/client/types.tsx
+++ b/packages/client/types.tsx
@@ -9,7 +9,7 @@ import {
     RouteProp,
 } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
-import { TracksMetadata } from '@musicroom/types';
+import { TrackMetadata } from '@musicroom/types';
 
 export type NavigateFromRefParams = {
     Alert: AlertParams;
@@ -63,7 +63,7 @@ interface MusicTrackVoteParams {
     roomId: string;
 }
 interface SearchTracksResultsParams {
-    tracks?: TracksMetadata[];
+    tracks?: TrackMetadata[];
 }
 
 /**

--- a/packages/server/app/Controllers/Http/Temporal/ServerToTemporalController.ts
+++ b/packages/server/app/Controllers/Http/Temporal/ServerToTemporalController.ts
@@ -44,6 +44,9 @@ interface TemporalMtvPauseArgs extends TemporalBaseArgs {}
 interface TemporalMtvPlayArgs extends TemporalBaseArgs {}
 interface TemporalMtvTerminateWorkflowArgs extends TemporalBaseArgs {}
 
+interface TemporalMtvSuggestTracksArgs extends TemporalBaseArgs {
+    tracksToSuggest: string[];
+}
 interface TemporalMtvGetStateArgs extends TemporalBaseArgs {
     userID?: string;
 }
@@ -239,5 +242,21 @@ export default class ServerToTemporalController {
                 'Failed to change user emitting device ' + workflowID,
             );
         }
+    }
+
+    public static async suggestTracks({
+        workflowID,
+        runID,
+        tracksToSuggest,
+    }: TemporalMtvSuggestTracksArgs): Promise<void> {
+        const url = urlcat(TEMPORAL_ENDPOINT, '/suggest-tracks');
+
+        await got.put(url, {
+            json: {
+                workflowID,
+                runID,
+                tracksToSuggest,
+            },
+        });
     }
 }

--- a/packages/server/app/Controllers/Http/Temporal/ServerToTemporalController.ts
+++ b/packages/server/app/Controllers/Http/Temporal/ServerToTemporalController.ts
@@ -46,6 +46,8 @@ interface TemporalMtvTerminateWorkflowArgs extends TemporalBaseArgs {}
 
 interface TemporalMtvSuggestTracksArgs extends TemporalBaseArgs {
     tracksToSuggest: string[];
+    userID: string;
+    deviceID: string;
 }
 interface TemporalMtvGetStateArgs extends TemporalBaseArgs {
     userID?: string;
@@ -248,6 +250,8 @@ export default class ServerToTemporalController {
         workflowID,
         runID,
         tracksToSuggest,
+        userID,
+        deviceID,
     }: TemporalMtvSuggestTracksArgs): Promise<void> {
         const url = urlcat(TEMPORAL_ENDPOINT, '/suggest-tracks');
 
@@ -256,6 +260,8 @@ export default class ServerToTemporalController {
                 workflowID,
                 runID,
                 tracksToSuggest,
+                userID,
+                deviceID,
             },
         });
     }

--- a/packages/server/app/Controllers/Http/Temporal/TemporalToServerController.ts
+++ b/packages/server/app/Controllers/Http/Temporal/TemporalToServerController.ts
@@ -111,4 +111,13 @@ export default class TemporalToServerController {
             [state],
         );
     }
+
+    public broadcastSuggestedTracksListUpdate({
+        request,
+    }: HttpContextContract): void {
+        const state = MtvWorkflowState.parse(request.body());
+        const roomID = state.roomID;
+
+        Ws.io.to(roomID).emit('SUGGEST_TRACKS_CALLBACK', state);
+    }
 }

--- a/packages/server/app/Controllers/Http/Temporal/TemporalToServerController.ts
+++ b/packages/server/app/Controllers/Http/Temporal/TemporalToServerController.ts
@@ -118,7 +118,7 @@ export default class TemporalToServerController {
         const state = MtvWorkflowState.parse(request.body());
         const roomID = state.roomID;
 
-        Ws.io.to(roomID).emit('SUGGEST_TRACKS_CALLBACK', state);
+        Ws.io.to(roomID).emit('SUGGESTED_TRACKS_LIST_UPDATE', state);
     }
 
     public async acknowledgeTracksSuggestion({
@@ -136,6 +136,6 @@ export default class TemporalToServerController {
 
         const device = await Device.findOrFail(deviceID);
 
-        Ws.io.in(device.socketID).emit('ACKNOWLEDGE_TRACKS_SUGGESTION');
+        Ws.io.in(device.socketID).emit('SUGGEST_TRACKS_CALLBACK');
     }
 }

--- a/packages/server/app/Controllers/Http/Temporal/TemporalToServerController.ts
+++ b/packages/server/app/Controllers/Http/Temporal/TemporalToServerController.ts
@@ -120,4 +120,22 @@ export default class TemporalToServerController {
 
         Ws.io.to(roomID).emit('SUGGEST_TRACKS_CALLBACK', state);
     }
+
+    public async acknowledgeTracksSuggestion({
+        request,
+    }: HttpContextContract): Promise<void> {
+        const AcknowledgeTracksSuggestionRequestBody = z.object({
+            roomID: z.string().uuid(),
+            userID: z.string().uuid(),
+            deviceID: z.string().uuid(),
+        });
+
+        const { deviceID } = AcknowledgeTracksSuggestionRequestBody.parse(
+            request.body(),
+        );
+
+        const device = await Device.findOrFail(deviceID);
+
+        Ws.io.in(device.socketID).emit('ACKNOWLEDGE_TRACKS_SUGGESTION');
+    }
 }

--- a/packages/server/app/Controllers/Http/TracksSearchesController.ts
+++ b/packages/server/app/Controllers/Http/TracksSearchesController.ts
@@ -47,7 +47,7 @@ export default class TracksSearchesController {
                     return undefined;
                 }
 
-                const trackMetadata = {
+                const trackMetadata: TrackMetadata = {
                     id: videoId,
                     title,
                     artistName: channelTitle,

--- a/packages/server/app/Controllers/Http/TracksSearchesController.ts
+++ b/packages/server/app/Controllers/Http/TracksSearchesController.ts
@@ -1,7 +1,7 @@
 import Env from '@ioc:Adonis/Core/Env';
 import { HttpContextContract } from '@ioc:Adonis/Core/HttpContext';
 import { google } from 'googleapis';
-import { TracksMetadata } from '@musicroom/types';
+import { TrackMetadata } from '@musicroom/types';
 
 const youtube = google.youtube({
     version: 'v3',
@@ -11,7 +11,7 @@ const youtube = google.youtube({
 export default class TracksSearchesController {
     public async searchTrackName({
         request,
-    }: HttpContextContract): Promise<TracksMetadata[] | undefined> {
+    }: HttpContextContract): Promise<TrackMetadata[] | undefined> {
         const params = request.params();
         const query = decodeURIComponent(params.query);
 
@@ -29,7 +29,7 @@ export default class TracksSearchesController {
             videoDuration: 'short', //less than 4 minutes
         });
 
-        const tracksMetadata: TracksMetadata[] | undefined = videos
+        const tracksMetadata: TrackMetadata[] | undefined = videos
             ?.map(({ id, snippet }) => {
                 if (id === undefined || snippet === undefined) {
                     return undefined;
@@ -56,7 +56,7 @@ export default class TracksSearchesController {
 
                 return trackMetadata;
             })
-            .filter(TracksMetadata.check.bind(TracksMetadata));
+            .filter(TrackMetadata.check.bind(TrackMetadata));
 
         return tracksMetadata;
     }

--- a/packages/server/app/Controllers/Ws/MtvRoomsWsController.ts
+++ b/packages/server/app/Controllers/Ws/MtvRoomsWsController.ts
@@ -43,7 +43,7 @@ interface OnTerminateArgs extends RoomID, RunID {}
 interface OnGetStateArgs extends RoomID, UserID {}
 interface OnGoToNextTrackArgs extends RoomID {}
 interface OnChangeEmittingDeviceArgs extends RoomID, DeviceID, UserID {}
-interface OnSuggestTracksArgs extends RoomID {
+interface OnSuggestTracksArgs extends RoomID, DeviceID, UserID {
     tracksToSuggest: string[];
 }
 
@@ -221,6 +221,8 @@ export default class MtvRoomsWsController {
     public static async onTracksSuggestion({
         roomID,
         tracksToSuggest,
+        userID,
+        deviceID,
     }: OnSuggestTracksArgs): Promise<void> {
         const { runID } = await MtvRoom.findOrFail(roomID);
 
@@ -228,6 +230,8 @@ export default class MtvRoomsWsController {
             workflowID: roomID,
             runID,
             tracksToSuggest,
+            userID,
+            deviceID,
         });
     }
 }

--- a/packages/server/app/Controllers/Ws/MtvRoomsWsController.ts
+++ b/packages/server/app/Controllers/Ws/MtvRoomsWsController.ts
@@ -10,11 +10,6 @@ import UserService from 'App/Services/UserService';
 import { randomUUID } from 'crypto';
 import ServerToTemporalController from '../Http/Temporal/ServerToTemporalController';
 
-// interface WsControllerMethodArgs<Payload> {
-//     socket: Socket<MtvRoomClientToServerEvents>;
-//     payload: Payload;
-// }
-
 interface UserID {
     userID: string;
 }
@@ -48,6 +43,9 @@ interface OnTerminateArgs extends RoomID, RunID {}
 interface OnGetStateArgs extends RoomID, UserID {}
 interface OnGoToNextTrackArgs extends RoomID {}
 interface OnChangeEmittingDeviceArgs extends RoomID, DeviceID, UserID {}
+interface OnSuggestTracksArgs extends RoomID {
+    tracksToSuggest: string[];
+}
 
 export default class MtvRoomsWsController {
     public static async onCreate({
@@ -217,6 +215,19 @@ export default class MtvRoomsWsController {
             runID,
             deviceID,
             userID,
+        });
+    }
+
+    public static async onTracksSuggestion({
+        roomID,
+        tracksToSuggest,
+    }: OnSuggestTracksArgs): Promise<void> {
+        const { runID } = await MtvRoom.findOrFail(roomID);
+
+        await ServerToTemporalController.suggestTracks({
+            workflowID: roomID,
+            runID,
+            tracksToSuggest,
         });
     }
 }

--- a/packages/server/start/routes.ts
+++ b/packages/server/start/routes.ts
@@ -50,11 +50,16 @@ Route.post(
 Route.post(
     'temporal/user-length-update',
     'Temporal/TemporalToServerController.userLengthUpdate',
-)
+);
 
 Route.post(
     '/temporal/suggested-tracks-list-changed',
     'Temporal/TemporalToServerController.broadcastSuggestedTracksListUpdate',
+);
+
+Route.post(
+    '/temporal/acknowledge-tracks-suggestion',
+    'Temporal/TemporalToServerController.acknowledgeTracksSuggestion',
 );
 
 /// //////// ////// ///

--- a/packages/server/start/routes.ts
+++ b/packages/server/start/routes.ts
@@ -50,6 +50,11 @@ Route.post(
 Route.post(
     'temporal/user-length-update',
     'Temporal/TemporalToServerController.userLengthUpdate',
+)
+
+Route.post(
+    '/temporal/suggested-tracks-list-changed',
+    'Temporal/TemporalToServerController.broadcastSuggestedTracksListUpdate',
 );
 
 /// //////// ////// ///

--- a/packages/server/start/socket.ts
+++ b/packages/server/start/socket.ts
@@ -323,10 +323,13 @@ Ws.io.on('connection', async (socket) => {
 
         socket.on('SUGGEST_TRACKS', async ({ tracksToSuggest }) => {
             try {
-                const { mtvRoomID } =
-                    await SocketLifecycle.getSocketConnectionCredentials(
-                        socket,
-                    );
+                const {
+                    mtvRoomID,
+                    user: { uuid: userID },
+                    deviceID,
+                } = await SocketLifecycle.getSocketConnectionCredentials(
+                    socket,
+                );
                 if (mtvRoomID === undefined) {
                     throw new Error(
                         'Can not go to the next track, the user is not listening to a mtv room',
@@ -336,6 +339,8 @@ Ws.io.on('connection', async (socket) => {
                 await MtvRoomsWsController.onTracksSuggestion({
                     roomID: mtvRoomID,
                     tracksToSuggest,
+                    userID,
+                    deviceID,
                 });
             } catch (err) {
                 console.error(err);

--- a/packages/server/start/socket.ts
+++ b/packages/server/start/socket.ts
@@ -332,7 +332,7 @@ Ws.io.on('connection', async (socket) => {
                 );
                 if (mtvRoomID === undefined) {
                     throw new Error(
-                        'Can not go to the next track, the user is not listening to a mtv room',
+                        'Can not suggest tracks, the user is not listening to a mtv room',
                     );
                 }
 

--- a/packages/server/start/socket.ts
+++ b/packages/server/start/socket.ts
@@ -320,6 +320,27 @@ Ws.io.on('connection', async (socket) => {
                 console.error(err);
             }
         });
+
+        socket.on('SUGGEST_TRACKS', async ({ tracksToSuggest }) => {
+            try {
+                const { mtvRoomID } =
+                    await SocketLifecycle.getSocketConnectionCredentials(
+                        socket,
+                    );
+                if (mtvRoomID === undefined) {
+                    throw new Error(
+                        'Can not go to the next track, the user is not listening to a mtv room',
+                    );
+                }
+
+                await MtvRoomsWsController.onTracksSuggestion({
+                    roomID: mtvRoomID,
+                    tracksToSuggest,
+                });
+            } catch (err) {
+                console.error(err);
+            }
+        });
         /// //// ///
 
         socket.on('disconnecting', async () => {

--- a/packages/server/tests/socketonDisconnection.test.ts
+++ b/packages/server/tests/socketonDisconnection.test.ts
@@ -1773,7 +1773,7 @@ test.group('Rooms life cycle', (group) => {
             roomCreatorUserID: userAID,
             roomID: mtvRoomIDToAssociate,
             tracks: null,
-            tracksIDsList: null,
+            suggestedTracks: null,
             userRelatedInformation: null,
             usersLength: 3,
         };
@@ -1818,10 +1818,11 @@ test.group('Rooms life cycle', (group) => {
                             artistName: name.findName(),
                             duration: 42000,
                             title: random.words(3),
+                            score: datatype.number(),
                         },
                     ],
+                    suggestedTracks: null,
                     currentTrack: null,
-                    tracksIDsList: null,
                 };
 
                 // Simulating Use Local Activity Notify

--- a/packages/server/tests/socketonDisconnection.test.ts
+++ b/packages/server/tests/socketonDisconnection.test.ts
@@ -201,6 +201,7 @@ test.group('Rooms life cycle', (group) => {
                             score: datatype.number(),
                         },
                     ],
+                    suggestedTracks: null,
                     currentTrack: null,
                 };
 
@@ -344,6 +345,7 @@ test.group('Rooms life cycle', (group) => {
                             score: datatype.number(),
                         },
                     ],
+                    suggestedTracks: null,
                 };
                 return {
                     runID: datatype.uuid(),
@@ -481,6 +483,7 @@ test.group('Rooms life cycle', (group) => {
                             score: datatype.number(),
                         },
                     ],
+                    suggestedTracks: null,
                     playing: false,
                     name: roomName,
                     userRelatedInformation: {
@@ -598,6 +601,7 @@ test.group('Rooms life cycle', (group) => {
                                 score: datatype.number(),
                             },
                         ],
+                        suggestedTracks: null,
                     },
                 };
             });
@@ -665,6 +669,7 @@ test.group('Rooms life cycle', (group) => {
                             score: datatype.number(),
                         },
                     ],
+                    suggestedTracks: null,
                 };
 
                 return {
@@ -690,6 +695,7 @@ test.group('Rooms life cycle', (group) => {
                         : null,
                     currentTrack: null,
                     tracks: null,
+                    suggestedTracks: null,
                 };
             });
         sinon.stub(ServerToTemporalController, 'play').callsFake(async () => {
@@ -776,6 +782,7 @@ test.group('Rooms life cycle', (group) => {
 
                     roomCreatorUserID: userID,
                     tracks: null,
+                    suggestedTracks: null,
                     userRelatedInformation: null,
                     usersLength: 1,
                 };
@@ -833,6 +840,7 @@ test.group('Rooms life cycle', (group) => {
             roomCreatorUserID: userID,
             roomID: datatype.uuid(),
             tracks: null,
+            suggestedTracks: null,
             usersLength: 1,
             userRelatedInformation: null,
         };
@@ -929,6 +937,7 @@ test.group('Rooms life cycle', (group) => {
                     roomCreatorUserID: userID,
                     roomID: workflowID,
                     tracks: null,
+                    suggestedTracks: null,
                     userRelatedInformation: {
                         userID: userID,
                         emittingDeviceID: deviceID,
@@ -1064,6 +1073,7 @@ test.group('Rooms life cycle', (group) => {
                     roomCreatorUserID: userID,
                     roomID: workflowID,
                     tracks: null,
+                    suggestedTracks: null,
                     userRelatedInformation: {
                         userID: userID,
                         emittingDeviceID: deviceID,
@@ -1126,6 +1136,7 @@ test.group('Rooms life cycle', (group) => {
                     roomCreatorUserID: userID,
                     roomID: workflowID,
                     tracks: null,
+                    suggestedTracks: null,
                     userRelatedInformation: {
                         userID: userID,
                         emittingDeviceID: deviceID,
@@ -1194,7 +1205,7 @@ test.group('Rooms life cycle', (group) => {
                     roomCreatorUserID: userID,
                     roomID: workflowID,
                     tracks: null,
-                    tracksIDsList: null,
+                    suggestedTracks: null,
                     userRelatedInformation: null,
                     usersLength: 2,
                 };
@@ -1350,7 +1361,7 @@ test.group('Rooms life cycle', (group) => {
             roomCreatorUserID: userAID,
             roomID: mtvRoomIDToAssociate,
             tracks: null,
-            tracksIDsList: null,
+            suggestedTracks: null,
             userRelatedInformation: null,
             usersLength: 3,
         };
@@ -1362,7 +1373,7 @@ test.group('Rooms life cycle', (group) => {
             roomCreatorUserID: roomToJoinCreatorID,
             roomID: mtvRoomToJoinID,
             tracks: null,
-            tracksIDsList: null,
+            suggestedTracks: null,
             userRelatedInformation: null,
             usersLength: 1,
         };
@@ -1558,7 +1569,7 @@ test.group('Rooms life cycle', (group) => {
             roomCreatorUserID: userAID,
             roomID: mtvRoomIDToAssociate,
             tracks: null,
-            tracksIDsList: null,
+            suggestedTracks: null,
             userRelatedInformation: null,
             usersLength: 3,
         };
@@ -1570,7 +1581,7 @@ test.group('Rooms life cycle', (group) => {
             roomCreatorUserID: roomToJoinCreatorID,
             roomID: mtvRoomToJoinID,
             tracks: null,
-            tracksIDsList: null,
+            suggestedTracks: null,
             userRelatedInformation: null,
             usersLength: 1,
         };

--- a/packages/server/tests/socketonDisconnection.test.ts
+++ b/packages/server/tests/socketonDisconnection.test.ts
@@ -198,10 +198,10 @@ test.group('Rooms life cycle', (group) => {
                             artistName: name.findName(),
                             duration: 42000,
                             title: random.words(3),
+                            score: datatype.number(),
                         },
                     ],
                     currentTrack: null,
-                    tracksIDsList: null,
                 };
 
                 // Simulating Use Local Activity Notify
@@ -335,13 +335,13 @@ test.group('Rooms life cycle', (group) => {
                     },
                     usersLength: 1,
                     currentTrack: null,
-                    tracksIDsList: null,
                     tracks: [
                         {
                             id: datatype.uuid(),
                             artistName: name.findName(),
                             duration: 42000,
                             title: random.words(3),
+                            score: datatype.number(),
                         },
                     ],
                 };
@@ -469,7 +469,6 @@ test.group('Rooms life cycle', (group) => {
             .stub(ServerToTemporalController, 'createMtvWorkflow')
             .callsFake(async ({ workflowID }) => {
                 state = {
-                    tracksIDsList: null,
                     currentTrack: null,
                     roomID: workflowID,
                     roomCreatorUserID: datatype.uuid(),
@@ -479,6 +478,7 @@ test.group('Rooms life cycle', (group) => {
                             artistName: name.findName(),
                             duration: 42000,
                             title: random.words(3),
+                            score: datatype.number(),
                         },
                     ],
                     playing: false,
@@ -583,7 +583,6 @@ test.group('Rooms life cycle', (group) => {
                         roomCreatorUserID: datatype.uuid(),
                         playing: false,
                         name: roomName,
-                        tracksIDsList: null,
                         currentTrack: null,
                         userRelatedInformation: {
                             userID,
@@ -596,6 +595,7 @@ test.group('Rooms life cycle', (group) => {
                                 artistName: name.findName(),
                                 duration: 42000,
                                 title: random.words(3),
+                                score: datatype.number(),
                             },
                         ],
                     },
@@ -650,7 +650,6 @@ test.group('Rooms life cycle', (group) => {
                     roomCreatorUserID: creatorUserID,
                     playing: false,
                     name: roomName,
-                    tracksIDsList: null,
                     usersLength: 1,
                     currentTrack: null,
                     userRelatedInformation: {
@@ -663,6 +662,7 @@ test.group('Rooms life cycle', (group) => {
                             artistName: name.findName(),
                             duration: 42000,
                             title: random.words(3),
+                            score: datatype.number(),
                         },
                     ],
                 };
@@ -689,7 +689,6 @@ test.group('Rooms life cycle', (group) => {
                           }
                         : null,
                     currentTrack: null,
-                    tracksIDsList: null,
                     tracks: null,
                 };
             });
@@ -777,7 +776,6 @@ test.group('Rooms life cycle', (group) => {
 
                     roomCreatorUserID: userID,
                     tracks: null,
-                    tracksIDsList: null,
                     userRelatedInformation: null,
                     usersLength: 1,
                 };
@@ -835,7 +833,6 @@ test.group('Rooms life cycle', (group) => {
             roomCreatorUserID: userID,
             roomID: datatype.uuid(),
             tracks: null,
-            tracksIDsList: null,
             usersLength: 1,
             userRelatedInformation: null,
         };
@@ -932,7 +929,6 @@ test.group('Rooms life cycle', (group) => {
                     roomCreatorUserID: userID,
                     roomID: workflowID,
                     tracks: null,
-                    tracksIDsList: null,
                     userRelatedInformation: {
                         userID: userID,
                         emittingDeviceID: deviceID,
@@ -1068,7 +1064,6 @@ test.group('Rooms life cycle', (group) => {
                     roomCreatorUserID: userID,
                     roomID: workflowID,
                     tracks: null,
-                    tracksIDsList: null,
                     userRelatedInformation: {
                         userID: userID,
                         emittingDeviceID: deviceID,
@@ -1131,7 +1126,6 @@ test.group('Rooms life cycle', (group) => {
                     roomCreatorUserID: userID,
                     roomID: workflowID,
                     tracks: null,
-                    tracksIDsList: null,
                     userRelatedInformation: {
                         userID: userID,
                         emittingDeviceID: deviceID,

--- a/packages/temporal/activities/mtv_controls.go
+++ b/packages/temporal/activities/mtv_controls.go
@@ -113,3 +113,23 @@ func SuggestedTracksListChangedActivity(ctx context.Context, state shared.MtvRoo
 
 	return err
 }
+
+type AcknowledgeTracksSuggestionArgs struct {
+	RoomID   string `json:"roomID"`
+	UserID   string `json:"userID"`
+	DeviceID string `json:"deviceID"`
+}
+
+func AcknowledgeTracksSuggestion(ctx context.Context, args AcknowledgeTracksSuggestionArgs) error {
+	requestBody := args
+
+	marshaledBody, err := json.Marshal(requestBody)
+	if err != nil {
+		return err
+	}
+
+	url := ADONIS_ENDPOINT + "/temporal/acknowledge-tracks-suggestion"
+	_, err = http.Post(url, "application/json", bytes.NewBuffer(marshaledBody))
+
+	return err
+}

--- a/packages/temporal/activities/mtv_metadata.go
+++ b/packages/temporal/activities/mtv_metadata.go
@@ -14,6 +14,12 @@ import (
 
 var ErrInvalidGoogleAPIKey = errors.New("invalid Google API key")
 
+type FetchedTracksInformationWithIniator struct {
+	Metadata []shared.TrackMetadata
+	UserID   string
+	DeviceID string
+}
+
 func FetchTracksInformationActivity(ctx context.Context, tracksIDs []string) ([]shared.TrackMetadata, error) {
 	metadata := make([]shared.TrackMetadata, 0, len(tracksIDs))
 
@@ -45,6 +51,19 @@ func FetchTracksInformationActivity(ctx context.Context, tracksIDs []string) ([]
 	}
 
 	return metadata, nil
+}
+
+func FetchTracksInformationActivityAndForwardIniator(ctx context.Context, tracksIDs []string, userID string, deviceID string) (FetchedTracksInformationWithIniator, error) {
+	metadata, err := FetchTracksInformationActivity(ctx, tracksIDs)
+	if err != nil {
+		return FetchedTracksInformationWithIniator{}, err
+	}
+
+	return FetchedTracksInformationWithIniator{
+		Metadata: metadata,
+		UserID:   userID,
+		DeviceID: deviceID,
+	}, nil
 }
 
 func isoDurationToDuration(d duration.Duration) time.Duration {

--- a/packages/temporal/api/main.go
+++ b/packages/temporal/api/main.go
@@ -173,6 +173,8 @@ type SuggestTracksRequestBody struct {
 	RunID      string `json:"runID"`
 
 	TracksToSuggest []string `json:"tracksToSuggest"`
+	UserID          string   `json:"userID"`
+	DeviceID        string   `json:"deviceID"`
 }
 
 func SuggestTracksHandler(w http.ResponseWriter, r *http.Request) {
@@ -187,6 +189,8 @@ func SuggestTracksHandler(w http.ResponseWriter, r *http.Request) {
 
 	suggestTracksSignal := shared.NewSuggestTracksSignal(shared.SuggestTracksSignalArgs{
 		TracksToSuggest: body.TracksToSuggest,
+		UserID:          body.UserID,
+		DeviceID:        body.DeviceID,
 	})
 	if err := temporal.SignalWorkflow(
 		context.Background(),

--- a/packages/temporal/shared/mtv.go
+++ b/packages/temporal/shared/mtv.go
@@ -313,15 +313,21 @@ func NewChangeUserEmittingDeviceSignal(args ChangeUserEmittingDeviceSignalArgs) 
 type SuggestTracksSignal struct {
 	Route           SignalRoute
 	TracksToSuggest []string
+	UserID          string
+	DeviceID        string
 }
 
 type SuggestTracksSignalArgs struct {
 	TracksToSuggest []string
+	UserID          string
+	DeviceID        string
 }
 
 func NewSuggestTracksSignal(args SuggestTracksSignalArgs) SuggestTracksSignal {
 	return SuggestTracksSignal{
 		Route:           SignalRouteSuggestTracks,
 		TracksToSuggest: args.TracksToSuggest,
+		UserID:          args.UserID,
+		DeviceID:        args.DeviceID,
 	}
 }

--- a/packages/temporal/worker/main.go
+++ b/packages/temporal/worker/main.go
@@ -20,7 +20,9 @@ func main() {
 	defer c.Close()
 	// This worker hosts both Worker and Activity functions
 	w := worker.New(c, shared.ControlTaskQueue, worker.Options{})
+
 	w.RegisterWorkflow(workflows.MtvRoomWorkflow)
+
 	w.RegisterActivity(activities.PingActivity)
 	w.RegisterActivity(activities.PlayActivity)
 	w.RegisterActivity(activities.PauseActivity)
@@ -29,6 +31,8 @@ func main() {
 	w.RegisterActivity(activities.FetchTracksInformationActivity)
 	w.RegisterActivity(activities.UserLengthUpdateActivity)
 	w.RegisterActivity(activities.ChangeUserEmittingDeviceActivity)
+	w.RegisterActivity(activities.SuggestedTracksListChangedActivity)
+
 	// Start listening to the Task Queue
 	err = w.Run(worker.InterruptCh())
 	if err != nil {

--- a/packages/temporal/worker/main.go
+++ b/packages/temporal/worker/main.go
@@ -33,6 +33,7 @@ func main() {
 	w.RegisterActivity(activities.UserLengthUpdateActivity)
 	w.RegisterActivity(activities.ChangeUserEmittingDeviceActivity)
 	w.RegisterActivity(activities.SuggestedTracksListChangedActivity)
+	w.RegisterActivity(activities.AcknowledgeTracksSuggestion)
 
 	// Start listening to the Task Queue
 	err = w.Run(worker.InterruptCh())

--- a/packages/temporal/worker/main.go
+++ b/packages/temporal/worker/main.go
@@ -29,6 +29,7 @@ func main() {
 	w.RegisterActivity(activities.JoinActivity)
 	w.RegisterActivity(activities.CreationAcknowledgementActivity)
 	w.RegisterActivity(activities.FetchTracksInformationActivity)
+	w.RegisterActivity(activities.FetchTracksInformationActivityAndForwardIniator)
 	w.RegisterActivity(activities.UserLengthUpdateActivity)
 	w.RegisterActivity(activities.ChangeUserEmittingDeviceActivity)
 	w.RegisterActivity(activities.SuggestedTracksListChangedActivity)

--- a/packages/temporal/workflows/mtv.go
+++ b/packages/temporal/workflows/mtv.go
@@ -227,15 +227,25 @@ type MtvRoomSuggestTracksEvent struct {
 	brainy.EventWithType
 
 	TracksToSuggest []string
+	UserID          string
+	DeviceID        string
 }
 
-func NewMtvRoomSuggestTracksEvent(tracksToSuggest []string) MtvRoomSuggestTracksEvent {
+type NewMtvRoomSuggestTracksEventArgs struct {
+	TracksToSuggest []string
+	UserID          string
+	DeviceID        string
+}
+
+func NewMtvRoomSuggestTracksEvent(args NewMtvRoomSuggestTracksEventArgs) MtvRoomSuggestTracksEvent {
 	return MtvRoomSuggestTracksEvent{
 		EventWithType: brainy.EventWithType{
 			Event: MtvRoomSuggestTracks,
 		},
 
-		TracksToSuggest: tracksToSuggest,
+		TracksToSuggest: args.TracksToSuggest,
+		UserID:          args.UserID,
+		DeviceID:        args.DeviceID,
 	}
 }
 
@@ -243,15 +253,25 @@ type MtvRoomSuggestedTracksFetchedEvent struct {
 	brainy.EventWithType
 
 	SuggestedTracksInformation []shared.TrackMetadata
+	UserID                     string
+	DeviceID                   string
 }
 
-func NewMtvRoomSuggestedTracksFetchedEvent(suggestedTracksInformation []shared.TrackMetadata) MtvRoomSuggestedTracksFetchedEvent {
+type NewMtvRoomSuggestedTracksFetchedEventArgs struct {
+	SuggestedTracksInformation []shared.TrackMetadata
+	UserID                     string
+	DeviceID                   string
+}
+
+func NewMtvRoomSuggestedTracksFetchedEvent(args NewMtvRoomSuggestedTracksFetchedEventArgs) MtvRoomSuggestedTracksFetchedEvent {
 	return MtvRoomSuggestedTracksFetchedEvent{
 		EventWithType: brainy.EventWithType{
 			Event: MtvRoomSuggestedTracksFetched,
 		},
 
-		SuggestedTracksInformation: suggestedTracksInformation,
+		SuggestedTracksInformation: args.SuggestedTracksInformation,
+		UserID:                     args.UserID,
+		DeviceID:                   args.DeviceID,
 	}
 }
 
@@ -683,8 +703,10 @@ func MtvRoomWorkflow(ctx workflow.Context, params shared.MtvRoomParameters) erro
 
 							fetchedSuggestedTracksInformationFuture = workflow.ExecuteActivity(
 								ctx,
-								activities.FetchTracksInformationActivity,
+								activities.FetchTracksInformationActivityAndForwardIniator,
 								acceptedSuggestedTracksIDs,
+								event.UserID,
+								event.DeviceID,
 							)
 
 							return nil
@@ -840,7 +862,11 @@ func MtvRoomWorkflow(ctx workflow.Context, params shared.MtvRoomParameters) erro
 				}
 
 				internalState.Machine.Send(
-					NewMtvRoomSuggestTracksEvent(message.TracksToSuggest),
+					NewMtvRoomSuggestTracksEvent(NewMtvRoomSuggestTracksEventArgs{
+						TracksToSuggest: message.TracksToSuggest,
+						UserID:          message.UserID,
+						DeviceID:        message.DeviceID,
+					}),
 				)
 
 			case shared.SignalRouteLeave:
@@ -927,7 +953,7 @@ func MtvRoomWorkflow(ctx workflow.Context, params shared.MtvRoomParameters) erro
 			selector.AddFuture(fetchedSuggestedTracksInformationFuture, func(f workflow.Future) {
 				fetchedSuggestedTracksInformationFuture = nil
 
-				var suggestedTracksInformationActivityResult []shared.TrackMetadata
+				var suggestedTracksInformationActivityResult activities.FetchedTracksInformationWithIniator
 
 				if err := f.Get(ctx, &suggestedTracksInformationActivityResult); err != nil {
 					logger.Error("error occured initialTracksActivityResult", err)
@@ -936,7 +962,11 @@ func MtvRoomWorkflow(ctx workflow.Context, params shared.MtvRoomParameters) erro
 				}
 
 				internalState.Machine.Send(
-					NewMtvRoomSuggestedTracksFetchedEvent(suggestedTracksInformationActivityResult),
+					NewMtvRoomSuggestedTracksFetchedEvent(NewMtvRoomSuggestedTracksFetchedEventArgs{
+						SuggestedTracksInformation: suggestedTracksInformationActivityResult.Metadata,
+						UserID:                     suggestedTracksInformationActivityResult.UserID,
+						DeviceID:                   suggestedTracksInformationActivityResult.DeviceID,
+					}),
 				)
 			})
 		}

--- a/packages/temporal/workflows/mtv_test.go
+++ b/packages/temporal/workflows/mtv_test.go
@@ -1009,6 +1009,8 @@ func (s *UnitTestSuite) Test_CanSuggestTracks() {
 		faker.UUIDHyphenated(),
 		faker.UUIDHyphenated(),
 	}
+	suggesterUserID := faker.UUIDHyphenated()
+	suggesterDeviceID := faker.UUIDHyphenated()
 	tracksToSuggestMetadata := []shared.TrackMetadata{
 		{
 			ID:         tracksIDsToSuggest[0],
@@ -1051,10 +1053,16 @@ func (s *UnitTestSuite) Test_CanSuggestTracks() {
 	).Return(tracks, nil).Once()
 	// Mock suggested and accepted tracks information fetching
 	s.env.OnActivity(
-		activities.FetchTracksInformationActivity,
+		activities.FetchTracksInformationActivityAndForwardIniator,
 		mock.Anything,
 		tracksIDsToSuggest,
-	).Return(tracksToSuggestMetadata, nil).Once()
+		suggesterUserID,
+		suggesterDeviceID,
+	).Return(activities.FetchedTracksInformationWithIniator{
+		Metadata: tracksToSuggestMetadata,
+		UserID:   suggesterUserID,
+		DeviceID: suggesterDeviceID,
+	}, nil).Once()
 
 	s.env.OnActivity(
 		activities.CreationAcknowledgementActivity,
@@ -1071,6 +1079,8 @@ func (s *UnitTestSuite) Test_CanSuggestTracks() {
 	registerDelayedCallbackWrapper(func() {
 		s.emitSuggestTrackSignal(shared.SuggestTracksSignalArgs{
 			TracksToSuggest: tracksIDsToSuggest,
+			UserID:          suggesterUserID,
+			DeviceID:        suggesterDeviceID,
 		})
 	}, firstSuggestTracksSignalDelay)
 
@@ -1086,6 +1096,8 @@ func (s *UnitTestSuite) Test_CanSuggestTracks() {
 	registerDelayedCallbackWrapper(func() {
 		s.emitSuggestTrackSignal(shared.SuggestTracksSignalArgs{
 			TracksToSuggest: []string{duplicateTrackIDToSuggest},
+			UserID:          suggesterUserID,
+			DeviceID:        suggesterDeviceID,
 		})
 	}, secondSuggestTracksSignalDelay)
 
@@ -1103,6 +1115,8 @@ func (s *UnitTestSuite) Test_CanSuggestTracks() {
 
 		s.emitSuggestTrackSignal(shared.SuggestTracksSignalArgs{
 			TracksToSuggest: []string{idOfTrackInTracksList},
+			UserID:          suggesterUserID,
+			DeviceID:        suggesterDeviceID,
 		})
 	}, thirdSuggestTracksSignalDelay)
 

--- a/packages/temporal/workflows/mtv_test.go
+++ b/packages/temporal/workflows/mtv_test.go
@@ -1074,6 +1074,15 @@ func (s *UnitTestSuite) Test_CanSuggestTracks() {
 		mock.Anything,
 		mock.Anything,
 	).Return(nil).Once()
+	s.env.OnActivity(
+		activities.AcknowledgeTracksSuggestion,
+		mock.Anything,
+		activities.AcknowledgeTracksSuggestionArgs{
+			RoomID:   params.RoomID,
+			UserID:   suggesterUserID,
+			DeviceID: suggesterDeviceID,
+		},
+	).Return(nil).Once()
 
 	firstSuggestTracksSignalDelay := defaultDuration
 	registerDelayedCallbackWrapper(func() {

--- a/packages/types/src/mtv-room-websockets.ts
+++ b/packages/types/src/mtv-room-websockets.ts
@@ -73,4 +73,5 @@ export interface MtvRoomServerToClientEvents {
     JOIN_ROOM_CALLBACK: (state: MtvWorkflowState) => void;
     CHANGE_EMITTING_DEVICE_CALLBACK: (state: MtvWorkflowState) => void;
     SUGGEST_TRACKS_CALLBACK: (state: MtvWorkflowState) => void;
+    ACKNOWLEDGE_TRACKS_SUGGESTION: () => void;
 }

--- a/packages/types/src/mtv-room-websockets.ts
+++ b/packages/types/src/mtv-room-websockets.ts
@@ -72,4 +72,5 @@ export interface MtvRoomServerToClientEvents {
     FORCED_DISCONNECTION: () => void;
     JOIN_ROOM_CALLBACK: (state: MtvWorkflowState) => void;
     CHANGE_EMITTING_DEVICE_CALLBACK: (state: MtvWorkflowState) => void;
+    SUGGEST_TRACKS_CALLBACK: (state: MtvWorkflowState) => void;
 }

--- a/packages/types/src/mtv-room-websockets.ts
+++ b/packages/types/src/mtv-room-websockets.ts
@@ -35,6 +35,10 @@ export interface MtvRoomClientToServerJoin {
     roomID: string;
 }
 
+export interface MtvRoomClientToServerSuggestTracks {
+    tracksToSuggest: string[];
+}
+
 export interface Track {
     name: string;
     artistName: string;
@@ -55,6 +59,7 @@ export interface MtvRoomClientToServerEvents {
     CHANGE_EMITTING_DEVICE: (
         args: MtvRoomClientToServerChangeUserEmittingDevice,
     ) => void;
+    SUGGEST_TRACKS: (args: MtvRoomClientToServerSuggestTracks) => void;
 }
 
 export interface MtvRoomServerToClientEvents {

--- a/packages/types/src/mtv-room-websockets.ts
+++ b/packages/types/src/mtv-room-websockets.ts
@@ -72,6 +72,6 @@ export interface MtvRoomServerToClientEvents {
     FORCED_DISCONNECTION: () => void;
     JOIN_ROOM_CALLBACK: (state: MtvWorkflowState) => void;
     CHANGE_EMITTING_DEVICE_CALLBACK: (state: MtvWorkflowState) => void;
-    SUGGEST_TRACKS_CALLBACK: (state: MtvWorkflowState) => void;
-    ACKNOWLEDGE_TRACKS_SUGGESTION: () => void;
+    SUGGESTED_TRACKS_LIST_UPDATE: (state: MtvWorkflowState) => void;
+    SUGGEST_TRACKS_CALLBACK: () => void;
 }

--- a/packages/types/src/mtv.ts
+++ b/packages/types/src/mtv.ts
@@ -26,18 +26,17 @@ export const UserRelatedInformation = z.object({
 });
 export type UserRelatedInformation = z.infer<typeof UserRelatedInformation>;
 
-export const MtvWorkflowState = z
-    .object({
-        roomID: z.string().uuid(),
-        roomCreatorUserID: z.string().uuid(),
-        playing: z.boolean(),
-        name: z.string(),
-        userRelatedInformation: UserRelatedInformation.nullable(),
-        usersLength: z.number(),
-        currentTrack: CurrentTrack.nullable(),
-        tracks: z.array(TrackMetadataWithScore).nullable(),
-    })
-    .nonstrict();
+export const MtvWorkflowState = z.object({
+    roomID: z.string().uuid(),
+    roomCreatorUserID: z.string().uuid(),
+    playing: z.boolean(),
+    name: z.string(),
+    userRelatedInformation: UserRelatedInformation.nullable(),
+    usersLength: z.number(),
+    currentTrack: CurrentTrack.nullable(),
+    tracks: z.array(TrackMetadataWithScore).nullable(),
+    suggestedTracks: z.array(TrackMetadataWithScore).nullable(),
+});
 export type MtvWorkflowState = z.infer<typeof MtvWorkflowState>;
 
 export const MtvWorkflowStateWithUserRelatedInformation =

--- a/packages/types/src/mtv.ts
+++ b/packages/types/src/mtv.ts
@@ -1,6 +1,6 @@
 import * as z from 'zod';
 
-const Milliseconds = z.number().positive();
+const Milliseconds = z.number().nonnegative();
 
 export const TrackMetadata = z.object({
     id: z.string(),

--- a/packages/types/src/mtv.ts
+++ b/packages/types/src/mtv.ts
@@ -1,15 +1,22 @@
 import * as z from 'zod';
 
-export const TracksMetadata = z.object({
+const Milliseconds = z.number().positive();
+
+export const TrackMetadata = z.object({
     id: z.string(),
     title: z.string(),
     artistName: z.string(),
-    duration: z.number(), //ms
+    duration: Milliseconds,
 });
-export type TracksMetadata = z.infer<typeof TracksMetadata>;
+export type TrackMetadata = z.infer<typeof TrackMetadata>;
 
-export const CurrentTrack = TracksMetadata.extend({
-    elapsed: z.number(), //ms
+export const TrackMetadataWithScore = TrackMetadata.extend({
+    score: z.number(),
+});
+export type TrackMetadataWithScore = z.infer<typeof TrackMetadataWithScore>;
+
+export const CurrentTrack = TrackMetadataWithScore.extend({
+    elapsed: Milliseconds,
 });
 export type CurrentTrack = z.infer<typeof CurrentTrack>;
 
@@ -28,8 +35,7 @@ export const MtvWorkflowState = z
         userRelatedInformation: UserRelatedInformation.nullable(),
         usersLength: z.number(),
         currentTrack: CurrentTrack.nullable(),
-        tracksIDsList: z.string().array().nullable(),
-        tracks: z.array(TracksMetadata).nullable(),
+        tracks: z.array(TrackMetadataWithScore).nullable(),
     })
     .nonstrict();
 export type MtvWorkflowState = z.infer<typeof MtvWorkflowState>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -17067,6 +17067,13 @@ react-native-screens@~3.0.0:
   resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-3.0.0.tgz#ee4c2d69abf7411603868b57214feec5e8f637fa"
   integrity sha512-35II5oxTaVp3OP8y0eLPOPpQkxG4fRKQ+dL1YSE1we5kCZFOU0l/Rn0T79HbyUu1LPwUZr6lZupPs0ULnRyMuQ==
 
+react-native-toast-message@^1.4.9:
+  version "1.4.9"
+  resolved "https://registry.yarnpkg.com/react-native-toast-message/-/react-native-toast-message-1.4.9.tgz#47f33ac312fe2aee5dbdd4ae14745fa0d354102e"
+  integrity sha512-QhHzzsiymKpHEWz2nUKQjQMRuGN+/a8cOwDXJcz3TQFY03p20f6sJW9JKw3KkMfvWiUhGbApCPpNU6tHaAZ32w==
+  dependencies:
+    prop-types "^15.7.2"
+
 react-native-web-webview@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/react-native-web-webview/-/react-native-web-webview-1.0.2.tgz#c215efa70c17589f2c8d640b1f1dc669b18c6e02"


### PR DESCRIPTION
Suggestions are now fully implemented.
The user will see an activity indicator while we are waiting for temporal acknowledgement. Once the acknowledgement came, we trigger a toast.

Everything works on native platforms and on the Web.

Users are informed that their request has been taken into account.
Closes #102

It marks the end of tracks suggestion step.
Closes #87 