### PR TITLE
fix(temporal,client): when the only track from list is loaded as curr…

### DIFF
--- a/packages/client/machines/appMusicPlayerMachine.ts
+++ b/packages/client/machines/appMusicPlayerMachine.ts
@@ -755,6 +755,10 @@ export const createAppMusicPlayerMachine = ({
                                                     {
                                                         target: 'waitingForTrackToLoad',
 
+                                                        /**
+                                                         * Checking if we're on a new track
+                                                         * Which means to reload a video in the players
+                                                         */
                                                         cond: (
                                                             { currentTrack },
                                                             {

--- a/packages/temporal/shared/mtv.go
+++ b/packages/temporal/shared/mtv.go
@@ -173,7 +173,7 @@ func (s *TracksMetadataWithScoreSet) Shift() (TrackMetadataWithScore, bool) {
 	return firstElement, true
 }
 
-func (s *TracksMetadataWithScoreSet) DeepEqual(toCmpTracksList TracksMetadataWithScoreSet) bool {
+func (s TracksMetadataWithScoreSet) DeepEqual(toCmpTracksList TracksMetadataWithScoreSet) bool {
 	if len(s.tracks) != len(toCmpTracksList.tracks) {
 		return false
 	}
@@ -196,6 +196,10 @@ type CurrentTrack struct {
 	TrackMetadataWithScore
 
 	AlreadyElapsed time.Duration `json:"-"`
+}
+
+func (s CurrentTrack) DeepEqual(toCmpCurrentTrack CurrentTrack) bool {
+	return s == toCmpCurrentTrack
 }
 
 type ExposedCurrentTrack struct {

--- a/packages/temporal/workflows/mtv_conds.go
+++ b/packages/temporal/workflows/mtv_conds.go
@@ -48,11 +48,13 @@ func userHasPermissionToPauseCurrentTrack(internalState *MtvRoomInternalState) b
 
 func currentTrackEndedAndNextTrackIsReadyToBePlayed(internalState *MtvRoomInternalState) brainy.Cond {
 	return func(c brainy.Context, e brainy.Event) bool {
+		//We might need a delta ? between elapsed and maxDuration
 		nextTrackIsReadyToBePlayed := internalState.Tracks.FirstTrackIsReadyToBePlayed(internalState.initialParams.MinimumScoreToBePlayed)
-		//See if we need a delta
-		//Remark: in case of all initials tracks fetching fails, we expect the room to autoplay
-		//the very next ready to be played track in the queue, in this way here we do not verify
-		//if the current is at it's default values aka internalState.CurrentTrack.Duration === 0
+		//Remark:
+		//If of all initials tracks fetching fails or not initial tracks are eligible to be
+		//load as currentTrack during room creation, we expect the room to autoplay
+		//the very next ready to be played track in the queue.
+		//In this way here we do not verify if the current track is at it's default value
 		currentTrackEnded := internalState.CurrentTrack.Duration == internalState.CurrentTrack.AlreadyElapsed
 
 		return currentTrackEnded && nextTrackIsReadyToBePlayed


### PR DESCRIPTION
…ent we compare current track