### PR TITLE
Cache deep clone of tracks

### DIFF
--- a/packages/temporal/shared/mtv.go
+++ b/packages/temporal/shared/mtv.go
@@ -59,6 +59,17 @@ type TracksMetadataWithScoreSet struct {
 	tracks []TrackMetadataWithScore
 }
 
+func (s *TracksMetadataWithScoreSet) Clone() TracksMetadataWithScoreSet {
+	originalTracks := s.Values()
+	copiedTracks := make([]TrackMetadataWithScore, len(originalTracks))
+
+	copy(copiedTracks, originalTracks)
+
+	return TracksMetadataWithScoreSet{
+		tracks: copiedTracks,
+	}
+}
+
 func (s *TracksMetadataWithScoreSet) Clear() {
 	s.tracks = []TrackMetadataWithScore{}
 }

--- a/packages/temporal/shared/mtv_test.go
+++ b/packages/temporal/shared/mtv_test.go
@@ -73,6 +73,12 @@ func (s *UnitTestSuite) Test_TracksMetadataWithScoreSetAllowsDeletion() {
 		set.Values(),
 	)
 	s.Equal(0, set.Len())
+
+	set.Add(setValues[0])
+
+	clone := set.Clone()
+	s.Equal(set.Values(), clone.Values())
+	s.NotSame(&set.Values()[0], &clone.Values()[0])
 }
 
 func TestUnitTestSuite(t *testing.T) {

--- a/packages/temporal/workflows/mtv.go
+++ b/packages/temporal/workflows/mtv.go
@@ -686,7 +686,7 @@ func MtvRoomWorkflow(ctx workflow.Context, params shared.MtvRoomParameters) erro
 							if needToNotifySuggestOrVoteUpdateActivity {
 								sendNotifySuggestOrVoteUpdateActivity(ctx, internalState.Export(shared.NoRelatedUserID))
 
-								internalState.TracksCheckForVoteUpdateLastSave = internalState.Tracks
+								internalState.TracksCheckForVoteUpdateLastSave = internalState.Tracks.Clone()
 								internalState.CurrentTrackCheckForVoteUpdateLastSave = internalState.CurrentTrack
 								voteIntervalTimerFuture = workflow.NewTimer(ctx, shared.CheckForVoteUpdateIntervalDuration)
 							} else {


### PR DESCRIPTION
If we assign `internalState.Tracks` to `internalState.TracksCheckForVoteUpdateLastSave`, the both sets will point to the same underlying tracks array.

We need to assign to `internalState.Tracks` a deep clone of tracks.