### PR TITLE
Listen for room state changes even when track is loading

### DIFF
--- a/packages/client/machines/appMusicPlayerMachine.ts
+++ b/packages/client/machines/appMusicPlayerMachine.ts
@@ -851,6 +851,24 @@ export const createAppMusicPlayerMachine = ({
                                             },
                                         },
                                     },
+
+                                    on: {
+                                        /**
+                                         * PAUSE_CALLBACK event must be handled in all substates, including waitingForTrackToLoad.
+                                         * The updated state must be assigned to the context.
+                                         */
+                                        PAUSE_CALLBACK: {
+                                            actions: 'assignMergeNewState',
+                                        },
+
+                                        /**
+                                         * PLAY_CALLBACK event must be handled in all substates, including waitingForTrackToLoad.
+                                         * The updated state must be assigned to the context.
+                                         */
+                                        PLAY_CALLBACK: {
+                                            actions: 'assignMergeNewState',
+                                        },
+                                    },
                                 },
 
                                 tracksSuggestion: {


### PR DESCRIPTION
When play button was pressed too fast by another user, the player was not synced.
This is because the play event was not handled by app music player machine.