### PR TITLE
Export MPE to MTV - Server

### DIFF
--- a/packages/server/app/Controllers/Http/Temporal/MpeServerToTemporalController.ts
+++ b/packages/server/app/Controllers/Http/Temporal/MpeServerToTemporalController.ts
@@ -16,6 +16,8 @@ import {
     MpeLeaveWorkflowResponseBody,
     MpeTerminateWorkflowRequestBody,
     MpeTerminateWorkflowResponseBody,
+    MpeExportToMtvResponseBody,
+    MpeExportToMtvRequestBody,
 } from '@musicroom/types';
 import got from 'got';
 import urlcat from 'urlcat';
@@ -105,6 +107,20 @@ export default class MpeServerToTemporalController {
         const url = urlcat(MPE_TEMPORAL_ENDPOINT, '/get-state');
 
         return MpeGetStateQueryResponseBody.parse(
+            await got
+                .put(url, {
+                    json: body,
+                })
+                .json(),
+        );
+    }
+
+    public static async exportToMtv(
+        body: MpeExportToMtvRequestBody,
+    ): Promise<MpeExportToMtvResponseBody> {
+        const url = urlcat(MPE_TEMPORAL_ENDPOINT, '/export-to-mtv');
+
+        return MpeExportToMtvResponseBody.parse(
             await got
                 .put(url, {
                     json: body,

--- a/packages/server/app/Controllers/Ws/MpeRoomsWsController.ts
+++ b/packages/server/app/Controllers/Ws/MpeRoomsWsController.ts
@@ -5,6 +5,7 @@ import {
     MpeCreateWorkflowResponse,
     MpeRoomClientToServerCreateArgs,
     MpeRoomServerToClientGetContextSuccessCallbackArgs,
+    MtvRoomCreationOptionsWithoutInitialTracksIDs,
 } from '@musicroom/types';
 import MpeRoom from 'App/Models/MpeRoom';
 import User from 'App/Models/User';
@@ -91,6 +92,13 @@ interface MpeOnLeaveRoomArgs {
 interface MpeOnTerminateArgs {
     user: User;
     roomID: string;
+}
+
+interface OnExportToMtvArgs {
+    userID: string;
+    deviceID: string;
+    roomID: string;
+    mtvRoomOptions: MtvRoomCreationOptionsWithoutInitialTracksIDs;
 }
 
 export default class MpeRoomsWsController {
@@ -372,6 +380,26 @@ export default class MpeRoomsWsController {
                 roomID,
             });
             throw new Error('onGetContext error');
+        }
+    }
+
+    public static async onExportToMtv({
+        roomID,
+        userID,
+        deviceID,
+        mtvRoomOptions,
+    }: OnExportToMtvArgs): Promise<void> {
+        try {
+            await MpeServerToTemporalController.exportToMtv({
+                workflowID: roomID,
+                userID,
+                deviceID,
+                mtvRoomOptions,
+            });
+        } catch (err) {
+            console.error(err);
+
+            throw new Error('onExportToMtv error');
         }
     }
 }

--- a/packages/server/app/Controllers/Ws/MtvRoomsWsController.ts
+++ b/packages/server/app/Controllers/Ws/MtvRoomsWsController.ts
@@ -1,7 +1,4 @@
-import { randomUUID } from 'crypto';
 import {
-    MtvCreateWorkflowResponse,
-    MtvRoomClientToServerCreateArgs,
     MtvRoomGetRoomConstraintDetailsCallbackArgs,
     MtvRoomSummary,
     MtvRoomUpdateControlAndDelegationPermissionArgs,
@@ -12,13 +9,10 @@ import {
 import MtvRoom from 'App/Models/MtvRoom';
 import MtvRoomInvitation from 'App/Models/MtvRoomInvitation';
 import User from 'App/Models/User';
-import GeocodingService from 'App/Services/GeocodingService';
 import SocketLifecycle from 'App/Services/SocketLifecycle';
 import UserService from 'App/Services/UserService';
 import { isPointWithinRadius } from 'geolib';
-import MtvServerToTemporalController, {
-    MtvRoomPhysicalAndTimeConstraintsWithCoords,
-} from '../Http/Temporal/MtvServerToTemporalController';
+import MtvServerToTemporalController from '../Http/Temporal/MtvServerToTemporalController';
 
 interface UserID {
     userID: string;
@@ -40,10 +34,6 @@ interface RunID {
     runID: string;
 }
 
-interface OnCreateArgs extends DeviceID {
-    params: MtvRoomClientToServerCreateArgs;
-    user: User;
-}
 interface OnJoinArgs extends UserID, DeviceID {
     joiningRoom: MtvRoom;
 }
@@ -113,138 +103,6 @@ interface OnGetRoomConstraintsDetailsArgs {
 }
 
 export default class MtvRoomsWsController {
-    public static async onCreate({
-        params,
-        user,
-        deviceID,
-    }: OnCreateArgs): Promise<MtvCreateWorkflowResponse> {
-        let physicalAndTimeConstraintsWithCoords:
-            | MtvRoomPhysicalAndTimeConstraintsWithCoords
-            | undefined;
-        let creatorFitsPositionConstraint: boolean | undefined;
-        const roomID = randomUUID();
-        const room = new MtvRoom();
-        let roomHasBeenSaved = false;
-        const userID = user.uuid;
-        console.log(`USER ${userID} MTV_CREATE_ROOM ${roomID}`);
-
-        if (
-            params.hasPhysicalAndTimeConstraints &&
-            params.physicalAndTimeConstraints !== undefined
-        ) {
-            const coords = await GeocodingService.getCoordsFromAddress(
-                params.physicalAndTimeConstraints.physicalConstraintPlaceID,
-            );
-            physicalAndTimeConstraintsWithCoords = {
-                ...params.physicalAndTimeConstraints,
-                physicalConstraintPosition: coords,
-            };
-
-            //Checking for last known user position, and checking if it fits
-            //With currently creating room position constraint to allow the creator
-            //to vote for it's initial track
-            creatorFitsPositionConstraint =
-                await this.checkUserDevicesPositionIfRoomHasPositionConstraints(
-                    {
-                        user,
-                        roomConstraintInformation: {
-                            constraintLat:
-                                physicalAndTimeConstraintsWithCoords
-                                    .physicalConstraintPosition.lat,
-                            constraintLng:
-                                physicalAndTimeConstraintsWithCoords
-                                    .physicalConstraintPosition.lng,
-                            constraintRadius:
-                                physicalAndTimeConstraintsWithCoords.physicalConstraintRadius,
-                            hasPositionAndTimeConstraints:
-                                params.hasPhysicalAndTimeConstraints,
-                        },
-                        //The workflow isn't already created
-                        persistToTemporalRequiredInformation: undefined,
-                    },
-                );
-            console.log({ creatorFitsPositionConstraint });
-        }
-
-        /**
-         * We need to create the socket-io room before the workflow
-         * because we don't know if temporal will answer faster via the acknowledge
-         * mtv room creation activity than adonis will execute this function
-         */
-        const roomCreator = await User.findOrFail(userID);
-        await UserService.joinEveryUserDevicesToRoom(roomCreator, roomID);
-
-        /**
-         * Check for room name duplication
-         * If room name is found in db
-         * Just add creator nickame after the room name
-         */
-        const roomWithCreatedRoomName = await MtvRoom.findBy(
-            'name',
-            params.name,
-        );
-        const roomNameIsAlreadyTaken = roomWithCreatedRoomName !== null;
-        if (roomNameIsAlreadyTaken) {
-            params.name = `${params.name} (${roomCreator.nickname})`;
-        }
-        ///
-
-        try {
-            const temporalResponse =
-                await MtvServerToTemporalController.createMtvWorkflow({
-                    workflowID: roomID,
-                    userID: userID,
-                    deviceID,
-                    params: {
-                        ...params,
-                        physicalAndTimeConstraints:
-                            physicalAndTimeConstraintsWithCoords,
-                        creatorFitsPositionConstraint,
-                    },
-                });
-
-            room.merge({
-                uuid: roomID,
-                runID: temporalResponse.runID,
-                name: params.name,
-                //By setting this field lucid will manage the BelongsTo relationship
-                creatorID: userID,
-                isOpen: params.isOpen,
-            });
-
-            if (
-                params.hasPhysicalAndTimeConstraints &&
-                params.physicalAndTimeConstraints !== undefined &&
-                physicalAndTimeConstraintsWithCoords
-            ) {
-                room.merge({
-                    hasPositionAndTimeConstraints:
-                        params.hasPhysicalAndTimeConstraints,
-                    constraintRadius:
-                        physicalAndTimeConstraintsWithCoords.physicalConstraintRadius,
-                    constraintLat:
-                        physicalAndTimeConstraintsWithCoords
-                            .physicalConstraintPosition.lat,
-                    constraintLng:
-                        physicalAndTimeConstraintsWithCoords
-                            .physicalConstraintPosition.lng,
-                });
-            }
-            await room.save();
-            roomHasBeenSaved = true;
-
-            await roomCreator.merge({ mtvRoomID: roomID }).save();
-            await room.related('members').save(roomCreator);
-            console.log('created room ' + roomID);
-            return temporalResponse;
-        } catch (error) {
-            await SocketLifecycle.deleteSocketIoRoom(roomID);
-            if (roomHasBeenSaved) await room.delete();
-
-            throw error;
-        }
-    }
-
     public static async onJoin({
         userID,
         joiningRoom: { runID, uuid: roomID, isOpen, creatorID },

--- a/packages/server/app/Services/MtvRoomService.ts
+++ b/packages/server/app/Services/MtvRoomService.ts
@@ -1,0 +1,72 @@
+import { MtvRoomCreationOptionsWithoutInitialTracksIDs } from '@musicroom/types';
+
+export class MtvRoomOptionsValidationError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'MtvRoomOptionsValidationError';
+    }
+}
+
+export class MtvRoomOptionsValidationInvalidInvitationOptionError extends MtvRoomOptionsValidationError {
+    constructor(message: string) {
+        super(message);
+        this.name = 'MtvRoomOptionsValidationInvalidInvitationOptionError';
+    }
+}
+
+export class MtvRoomOptionsValidationInvalidPhysicalAndTimeConstraintsOptionError extends MtvRoomOptionsValidationError {
+    constructor(message: string) {
+        super(message);
+        this.name =
+            'MtvRoomOptionsValidationInvalidPhysicalAndTimeConstraintsOptionError';
+    }
+}
+
+export class MtvRoomOptionsValidationInvalidNameOptionError extends MtvRoomOptionsValidationError {
+    constructor(message: string) {
+        super(message);
+        this.name = 'MtvRoomOptionsValidationInvalidNameOptionError';
+    }
+}
+
+export default class MtvRoomService {
+    /**
+     * Throws an error if there are race conditions in mtv room creation options.
+     */
+    public static validateMtvRoomOptions(
+        options: MtvRoomCreationOptionsWithoutInitialTracksIDs,
+    ): void {
+        if (
+            options.isOpen === false &&
+            options.isOpenOnlyInvitedUsersCanVote === true
+        ) {
+            throw new MtvRoomOptionsValidationInvalidInvitationOptionError(
+                'isOpenOnlyInvitedUsersCanVote true when isOpen is false; isOpenOnlyInvitedUsersCanVote can be true only when isOpen is true too',
+            );
+        }
+
+        if (
+            options.hasPhysicalAndTimeConstraints === true &&
+            options.physicalAndTimeConstraints === undefined
+        ) {
+            throw new MtvRoomOptionsValidationInvalidPhysicalAndTimeConstraintsOptionError(
+                'hasPhysicalAndTimeConstraints is true but physicalAndTimeConstraints is undefined; physicalAndTimeConstraints must be defined when hasPhysicalAndTimeConstraints is true',
+            );
+        }
+
+        if (
+            options.hasPhysicalAndTimeConstraints === false &&
+            options.physicalAndTimeConstraints !== undefined
+        ) {
+            throw new MtvRoomOptionsValidationInvalidPhysicalAndTimeConstraintsOptionError(
+                'physicalAndTimeConstraints is defined but hasPhysicalAndTimeConstraints is false; physicalAndTimeConstraints must be undefined when hasPhysicalAndTimeConstraints is false',
+            );
+        }
+
+        if (options.name === '') {
+            throw new MtvRoomOptionsValidationInvalidNameOptionError(
+                'name must not be empty',
+            );
+        }
+    }
+}

--- a/packages/server/app/Services/MtvRoomService.ts
+++ b/packages/server/app/Services/MtvRoomService.ts
@@ -1,10 +1,19 @@
+import { randomUUID } from 'crypto';
 import {
+    MtvCreateWorkflowResponse,
     MtvRoomClientToServerCreateArgs,
     MtvRoomCreationOptionsWithoutInitialTracksIDs,
 } from '@musicroom/types';
+import MtvServerToTemporalController, {
+    MtvRoomPhysicalAndTimeConstraintsWithCoords,
+} from 'App/Controllers/Http/Temporal/MtvServerToTemporalController';
 import MtvRoomsWsController from 'App/Controllers/Ws/MtvRoomsWsController';
 import User from 'App/Models/User';
+import MtvRoom from 'App/Models/MtvRoom';
 import Ws from './Ws';
+import GeocodingService from './GeocodingService';
+import UserService from './UserService';
+import SocketLifecycle from './SocketLifecycle';
 
 export class MtvRoomOptionsValidationError extends Error {
     constructor(message: string) {
@@ -40,6 +49,12 @@ interface MtvRoomServiceCreateMtvRoomArgs {
     user: User;
     deviceID: string;
     currentMtvRoomID?: string;
+}
+
+interface MtvRoomServiceCreateMtvRoomWorkflowArgs {
+    deviceID: string;
+    params: MtvRoomClientToServerCreateArgs;
+    user: User;
 }
 
 export default class MtvRoomService {
@@ -107,7 +122,7 @@ export default class MtvRoomService {
             });
         }
 
-        const mtvRoomState = await MtvRoomsWsController.onCreate({
+        const mtvRoomState = await MtvRoomService.createMtvRoomWorkflow({
             params: options,
             user,
             deviceID,
@@ -116,5 +131,137 @@ export default class MtvRoomService {
         Ws.io
             .to(mtvRoomState.workflowID)
             .emit('MTV_CREATE_ROOM_SYNCHED_CALLBACK', mtvRoomState.state);
+    }
+
+    private static async createMtvRoomWorkflow({
+        params,
+        user,
+        deviceID,
+    }: MtvRoomServiceCreateMtvRoomWorkflowArgs): Promise<MtvCreateWorkflowResponse> {
+        let physicalAndTimeConstraintsWithCoords:
+            | MtvRoomPhysicalAndTimeConstraintsWithCoords
+            | undefined;
+        let creatorFitsPositionConstraint: boolean | undefined;
+        const roomID = randomUUID();
+        const room = new MtvRoom();
+        let roomHasBeenSaved = false;
+        const userID = user.uuid;
+        console.log(`USER ${userID} MTV_CREATE_ROOM ${roomID}`);
+
+        if (
+            params.hasPhysicalAndTimeConstraints &&
+            params.physicalAndTimeConstraints !== undefined
+        ) {
+            const coords = await GeocodingService.getCoordsFromAddress(
+                params.physicalAndTimeConstraints.physicalConstraintPlaceID,
+            );
+            physicalAndTimeConstraintsWithCoords = {
+                ...params.physicalAndTimeConstraints,
+                physicalConstraintPosition: coords,
+            };
+
+            //Checking for last known user position, and checking if it fits
+            //With currently creating room position constraint to allow the creator
+            //to vote for it's initial track
+            creatorFitsPositionConstraint =
+                await MtvRoomsWsController.checkUserDevicesPositionIfRoomHasPositionConstraints(
+                    {
+                        user,
+                        roomConstraintInformation: {
+                            constraintLat:
+                                physicalAndTimeConstraintsWithCoords
+                                    .physicalConstraintPosition.lat,
+                            constraintLng:
+                                physicalAndTimeConstraintsWithCoords
+                                    .physicalConstraintPosition.lng,
+                            constraintRadius:
+                                physicalAndTimeConstraintsWithCoords.physicalConstraintRadius,
+                            hasPositionAndTimeConstraints:
+                                params.hasPhysicalAndTimeConstraints,
+                        },
+                        //The workflow isn't already created
+                        persistToTemporalRequiredInformation: undefined,
+                    },
+                );
+            console.log({ creatorFitsPositionConstraint });
+        }
+
+        /**
+         * We need to create the socket-io room before the workflow
+         * because we don't know if temporal will answer faster via the acknowledge
+         * mtv room creation activity than adonis will execute this function
+         */
+        const roomCreator = await User.findOrFail(userID);
+        await UserService.joinEveryUserDevicesToRoom(roomCreator, roomID);
+
+        /**
+         * Check for room name duplication
+         * If room name is found in db
+         * Just add creator nickame after the room name
+         */
+        const roomWithCreatedRoomName = await MtvRoom.findBy(
+            'name',
+            params.name,
+        );
+        const roomNameIsAlreadyTaken = roomWithCreatedRoomName !== null;
+        if (roomNameIsAlreadyTaken) {
+            params.name = `${params.name} (${roomCreator.nickname})`;
+        }
+        ///
+
+        try {
+            const temporalResponse =
+                await MtvServerToTemporalController.createMtvWorkflow({
+                    workflowID: roomID,
+                    userID: userID,
+                    deviceID,
+                    params: {
+                        ...params,
+                        physicalAndTimeConstraints:
+                            physicalAndTimeConstraintsWithCoords,
+                        creatorFitsPositionConstraint,
+                    },
+                });
+
+            room.merge({
+                uuid: roomID,
+                runID: temporalResponse.runID,
+                name: params.name,
+                //By setting this field lucid will manage the BelongsTo relationship
+                creatorID: userID,
+                isOpen: params.isOpen,
+            });
+
+            if (
+                params.hasPhysicalAndTimeConstraints &&
+                params.physicalAndTimeConstraints !== undefined &&
+                physicalAndTimeConstraintsWithCoords
+            ) {
+                room.merge({
+                    hasPositionAndTimeConstraints:
+                        params.hasPhysicalAndTimeConstraints,
+                    constraintRadius:
+                        physicalAndTimeConstraintsWithCoords.physicalConstraintRadius,
+                    constraintLat:
+                        physicalAndTimeConstraintsWithCoords
+                            .physicalConstraintPosition.lat,
+                    constraintLng:
+                        physicalAndTimeConstraintsWithCoords
+                            .physicalConstraintPosition.lng,
+                });
+            }
+            await room.save();
+            roomHasBeenSaved = true;
+
+            await roomCreator.merge({ mtvRoomID: roomID }).save();
+            await room.related('members').save(roomCreator);
+            console.log('created room ' + roomID);
+            return temporalResponse;
+        } catch (error) {
+            await SocketLifecycle.deleteSocketIoRoom(roomID);
+            if (roomHasBeenSaved) await room.delete();
+
+            throw error;
+        }
     }
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -61,6 +61,7 @@
     "reflect-metadata": "^0.1.13",
     "socket.io": "^4.1.2",
     "source-map-support": "^0.5.19",
+    "tiny-invariant": "^1.2.0",
     "ua-parser-js": "^0.7.28",
     "urlcat": "^2.0.4",
     "zod": "^1.11.17"

--- a/packages/server/start/mpeSocket.ts
+++ b/packages/server/start/mpeSocket.ts
@@ -183,8 +183,8 @@ export default function initMpeSocketEventListeners(socket: TypedSocket): void {
                 await SocketLifecycle.getSocketConnectionCredentials(socket);
 
             await MpeRoomsWsController.onExportToMtv({
+                user,
                 roomID,
-                userID: user.uuid,
                 deviceID,
                 mtvRoomOptions,
             });

--- a/packages/server/start/mpeSocket.ts
+++ b/packages/server/start/mpeSocket.ts
@@ -183,7 +183,7 @@ export default function initMpeSocketEventListeners(socket: TypedSocket): void {
                 await SocketLifecycle.getSocketConnectionCredentials(socket);
 
             await MpeRoomsWsController.onExportToMtv({
-                user,
+                userID: user.uuid,
                 roomID,
                 deviceID,
                 mtvRoomOptions,

--- a/packages/server/start/mpeSocket.ts
+++ b/packages/server/start/mpeSocket.ts
@@ -4,6 +4,7 @@ import {
     MpeRoomClientToServerChangeTrackOrderUpDownArgs,
     MpeRoomClientToServerCreateArgs,
     MpeRoomClientToServerDeleteTracksArgs,
+    MpeRoomClientToServerExportToMtvArgs,
     MpeRoomClientToServerGetContextArgs,
     MpeRoomClientToServerJoinRoomArgs,
     MpeRoomClientToServerLeaveRoomArgs,
@@ -165,6 +166,25 @@ export default function initMpeSocketEventListeners(socket: TypedSocket): void {
             });
 
             socket.emit('MPE_GET_CONTEXT_SUCCESS_CALLBACK', response);
+        } catch (err) {
+            console.error(err);
+        }
+    });
+
+    socket.on('MPE_EXPORT_TO_MTV', async (rawArgs) => {
+        try {
+            const { roomID, mtvRoomOptions } =
+                MpeRoomClientToServerExportToMtvArgs.parse(rawArgs);
+
+            const { user, deviceID } =
+                await SocketLifecycle.getSocketConnectionCredentials(socket);
+
+            await MpeRoomsWsController.onExportToMtv({
+                roomID,
+                userID: user.uuid,
+                deviceID,
+                mtvRoomOptions,
+            });
         } catch (err) {
             console.error(err);
         }

--- a/packages/server/start/mpeSocket.ts
+++ b/packages/server/start/mpeSocket.ts
@@ -10,6 +10,7 @@ import {
     MpeRoomClientToServerLeaveRoomArgs,
 } from '@musicroom/types';
 import MpeRoomsWsController from 'App/Controllers/Ws/MpeRoomsWsController';
+import MtvRoomService from 'App/Services/MtvRoomService';
 import SocketLifecycle from 'App/Services/SocketLifecycle';
 import Ws from 'App/Services/Ws';
 import { TypedSocket } from './socket';
@@ -175,6 +176,8 @@ export default function initMpeSocketEventListeners(socket: TypedSocket): void {
         try {
             const { roomID, mtvRoomOptions } =
                 MpeRoomClientToServerExportToMtvArgs.parse(rawArgs);
+
+            MtvRoomService.validateMtvRoomOptions(mtvRoomOptions);
 
             const { user, deviceID } =
                 await SocketLifecycle.getSocketConnectionCredentials(socket);

--- a/packages/server/start/mtvSocket.ts
+++ b/packages/server/start/mtvSocket.ts
@@ -37,31 +37,15 @@ export default function initMtvSocketEventListeners(socket: TypedSocket): void {
             const {
                 user,
                 deviceID,
-                mtvRoomID: currMtvRoomID,
+                mtvRoomID: currentMtvRoomID,
             } = await SocketLifecycle.getSocketConnectionCredentials(socket);
 
-            /**
-             * Checking if user needs to leave previous
-             * mtv room before creating new one
-             */
-            if (currMtvRoomID !== undefined) {
-                console.log(
-                    `User needs to leave current room before joining new one`,
-                );
-                await MtvRoomsWsController.onLeave({
-                    user,
-                    leavingRoomID: currMtvRoomID,
-                });
-            }
-
-            const raw = await MtvRoomsWsController.onCreate({
-                params: payload,
+            await MtvRoomService.createMtvRoom({
                 user,
                 deviceID,
+                options: payload,
+                currentMtvRoomID,
             });
-            Ws.io
-                .to(raw.workflowID)
-                .emit('MTV_CREATE_ROOM_SYNCHED_CALLBACK', raw.state);
         } catch (e) {
             console.error(e);
         }

--- a/packages/server/start/mtvSocket.ts
+++ b/packages/server/start/mtvSocket.ts
@@ -7,7 +7,6 @@ import {
 import MtvRoomsWsController from 'App/Controllers/Ws/MtvRoomsWsController';
 import Device from 'App/Models/Device';
 import SocketLifecycle from 'App/Services/SocketLifecycle';
-import Ws from 'App/Services/Ws';
 import MtvRoomsChatController from 'App/Controllers/Ws/MtvRoomsChatController';
 import MtvRoomService from 'App/Services/MtvRoomService';
 import { TypedSocket } from './socket';

--- a/packages/server/start/routes.ts
+++ b/packages/server/start/routes.ts
@@ -145,6 +145,11 @@ Route.group(() => {
     );
 
     Route.post(
+        `/request-mtv-room-creation`,
+        'Temporal/MpeTemporalToServerController.requestMtvRoomCreation',
+    );
+
+    Route.post(
         `/acknowledge-leave`,
         `Temporal/MpeTemporalToServerController.mpeLeaveAcknowledgement`,
     );

--- a/packages/server/start/routes.ts
+++ b/packages/server/start/routes.ts
@@ -36,7 +36,7 @@ Route.post('/mpe/search/all-rooms', 'MpeRoomsHttpController.listAllRooms');
 
 /// Temporal MTV Routes ///
 
-const MTV_TEMPORAL_LISTENER = `/temporal/mtv`;
+export const MTV_TEMPORAL_LISTENER = `/temporal/mtv`;
 
 Route.group(() => {
     Route.post(

--- a/packages/server/tests/MpeExportToMtv.test.ts
+++ b/packages/server/tests/MpeExportToMtv.test.ts
@@ -1,0 +1,176 @@
+import Database from '@ioc:Adonis/Lucid/Database';
+import {
+    MpeRequestMtvRoomCreationRequestBody,
+    MtvCreateWorkflowResponse,
+    MtvRoomCreationOptionsWithoutInitialTracksIDs,
+    MtvWorkflowStateWithUserRelatedInformation,
+} from '@musicroom/types';
+import MpeServerToTemporalController from 'App/Controllers/Http/Temporal/MpeServerToTemporalController';
+import MtvServerToTemporalController from 'App/Controllers/Http/Temporal/MtvServerToTemporalController';
+import { datatype, random, name } from 'faker';
+import test from 'japa';
+import sinon from 'sinon';
+import supertest from 'supertest';
+import urlcat from 'urlcat';
+import { MPE_TEMPORAL_LISTENER, MTV_TEMPORAL_LISTENER } from '../start/routes';
+import {
+    BASE_URL,
+    initTestUtils,
+    createSpyOnClientSocketEvent,
+} from './utils/TestUtils';
+
+test.group('MPE Export to MTV', (group) => {
+    const {
+        createUserAndGetSocket,
+        disconnectEveryRemainingSocketConnection,
+        initSocketConnection,
+        waitFor,
+    } = initTestUtils();
+
+    group.beforeEach(async () => {
+        initSocketConnection();
+        await Database.beginGlobalTransaction();
+    });
+
+    group.afterEach(async () => {
+        await disconnectEveryRemainingSocketConnection();
+        sinon.restore();
+        await Database.rollbackGlobalTransaction();
+    });
+
+    test('Exporting a MPE room creates a MTV room', async (assert) => {
+        const creatorUserID = datatype.uuid();
+        const roomID = datatype.uuid();
+        const userASocket1 = await createUserAndGetSocket({
+            userID: creatorUserID,
+            mpeRoomIDToAssociate: [
+                {
+                    roomID,
+                },
+            ],
+        });
+        const mtvRoomOptions: MtvRoomCreationOptionsWithoutInitialTracksIDs = {
+            name: random.words(),
+            isOpen: true,
+            isOpenOnlyInvitedUsersCanVote: false,
+            hasPhysicalAndTimeConstraints: false,
+            minimumScoreToBePlayed: 1,
+            playingMode: 'BROADCAST',
+        };
+        const mpeRoomInitialTracksIDs = [datatype.uuid(), datatype.uuid()];
+
+        sinon
+            .stub(MpeServerToTemporalController, 'exportToMtv')
+            .callsFake((args) => {
+                assert.equal(args.workflowID, roomID);
+                assert.equal(args.userID, creatorUserID);
+                assert.deepEqual(args.mtvRoomOptions, mtvRoomOptions);
+
+                setTimeout(async function sendMtvRoomCreationRequest() {
+                    const body: MpeRequestMtvRoomCreationRequestBody = {
+                        userID: args.userID,
+                        deviceID: args.deviceID,
+                        mtvRoomOptions: args.mtvRoomOptions,
+                        tracksIDs: mpeRoomInitialTracksIDs,
+                    };
+
+                    await supertest(BASE_URL)
+                        .post(
+                            urlcat(
+                                MPE_TEMPORAL_LISTENER,
+                                'request-mtv-room-creation',
+                            ),
+                        )
+                        .send(body)
+                        .expect(200);
+                }, 10);
+
+                return Promise.resolve({
+                    ok: 1,
+                });
+            });
+        sinon
+            .stub(MtvServerToTemporalController, 'createMtvWorkflow')
+            .callsFake(async ({ workflowID, params }) => {
+                const mtvRoomState: MtvCreateWorkflowResponse = {
+                    runID: datatype.uuid(),
+                    workflowID,
+                    state: {
+                        name: params.name,
+                        isOpen: params.isOpen,
+
+                        roomID: workflowID,
+                        roomCreatorUserID: datatype.uuid(),
+                        delegationOwnerUserID: null,
+                        hasTimeAndPositionConstraints: false,
+                        isOpenOnlyInvitedUsersCanVote: false,
+                        timeConstraintIsValid: null,
+                        playing: false,
+                        playingMode: 'BROADCAST',
+                        currentTrack: null,
+                        userRelatedInformation: {
+                            userID: creatorUserID,
+                            emittingDeviceID: datatype.uuid(),
+                            tracksVotedFor: [],
+                            userFitsPositionConstraint: null,
+                            hasControlAndDelegationPermission: true,
+                            userHasBeenInvited: false,
+                        },
+                        usersLength: 1,
+                        tracks: [
+                            {
+                                id: datatype.uuid(),
+                                artistName: name.findName(),
+                                duration: 42000,
+                                title: random.words(3),
+                                score: datatype.number(),
+                            },
+                        ],
+                        minimumScoreToBePlayed: 1,
+                    },
+                };
+
+                setTimeout(async function sendCreationAcknowledgementRequest() {
+                    const body: MtvWorkflowStateWithUserRelatedInformation =
+                        mtvRoomState.state;
+
+                    await supertest(BASE_URL)
+                        .post(
+                            urlcat(
+                                MTV_TEMPORAL_LISTENER,
+                                '/mtv-creation-acknowledgement',
+                            ),
+                        )
+                        .send(body);
+                }, 10);
+
+                return mtvRoomState;
+            });
+
+        const userASocket1CreateRoomCallbackSpy = createSpyOnClientSocketEvent(
+            userASocket1,
+            'MTV_CREATE_ROOM_CALLBACK',
+        );
+        const userASocket1CreateRoomSynchedCallbackSpy =
+            createSpyOnClientSocketEvent(
+                userASocket1,
+                'MTV_CREATE_ROOM_SYNCHED_CALLBACK',
+            );
+
+        userASocket1.emit('MPE_EXPORT_TO_MTV', {
+            roomID,
+            mtvRoomOptions,
+        });
+
+        await Promise.all([
+            waitFor(() => {
+                assert.isTrue(userASocket1CreateRoomCallbackSpy.calledOnce);
+            }),
+            waitFor(() => {
+                assert.isTrue(
+                    userASocket1CreateRoomSynchedCallbackSpy.calledOnce,
+                );
+            }),
+        ]);
+    });
+});

--- a/packages/types/src/mpe-room-websockets.ts
+++ b/packages/types/src/mpe-room-websockets.ts
@@ -1,4 +1,5 @@
 import * as z from 'zod';
+import { MtvRoomClientToServerCreateArgs } from './mtv-room-websockets';
 import { MpeWorkflowState, MpeRoomSummary } from './mpe';
 
 //Client to server
@@ -73,6 +74,22 @@ export const MpeRoomClientToServerLeaveRoomArgs = z.object({
 });
 export type MpeRoomClientToServerLeaveRoomArgs = z.infer<
     typeof MpeRoomClientToServerLeaveRoomArgs
+>;
+
+export const MtvRoomCreationOptionsWithoutInitialTracksIDs =
+    MtvRoomClientToServerCreateArgs.omit({
+        initialTracksIDs: true,
+    });
+export type MtvRoomCreationOptionsWithoutInitialTracksIDs = z.infer<
+    typeof MtvRoomCreationOptionsWithoutInitialTracksIDs
+>;
+
+export const MpeRoomClientToServerExportToMtvArgs = z.object({
+    roomID: z.string().uuid(),
+    mtvRoomOptions: MtvRoomCreationOptionsWithoutInitialTracksIDs,
+});
+export type MpeRoomClientToServerExportToMtvArgs = z.infer<
+    typeof MpeRoomClientToServerExportToMtvArgs
 >;
 ///
 
@@ -168,6 +185,7 @@ export interface MpeRoomClientToServerEvents {
     MPE_GET_CONTEXT: (args: MpeRoomClientToServerGetContextArgs) => void;
     MPE_JOIN_ROOM: (args: MpeRoomClientToServerJoinRoomArgs) => void;
     MPE_LEAVE_ROOM: (args: MpeRoomClientToServerLeaveRoomArgs) => void;
+    MPE_EXPORT_TO_MTV: (args: MpeRoomClientToServerExportToMtvArgs) => void;
 }
 
 export interface MpeRoomServerToClientEvents {

--- a/packages/types/src/mpe-server-to-temporal.ts
+++ b/packages/types/src/mpe-server-to-temporal.ts
@@ -1,4 +1,5 @@
 import * as z from 'zod';
+import { MtvRoomCreationOptionsWithoutInitialTracksIDs } from './mpe-room-websockets';
 import { MpeWorkflowState } from './mpe';
 
 export const MpeCreateWorkflowResponse = z.object({
@@ -89,6 +90,23 @@ export const MpeGetStateQueryRequestBody = z.object({
 });
 export type MpeGetStateQueryRequestBody = z.infer<
     typeof MpeGetStateQueryRequestBody
+>;
+
+export const MpeExportToMtvRequestBody = z.object({
+    workflowID: z.string().uuid(),
+    userID: z.string(),
+    deviceID: z.string(),
+    mtvRoomOptions: MtvRoomCreationOptionsWithoutInitialTracksIDs,
+});
+export type MpeExportToMtvRequestBody = z.infer<
+    typeof MpeExportToMtvRequestBody
+>;
+
+export const MpeExportToMtvResponseBody = z.object({
+    ok: z.literal(1),
+});
+export type MpeExportToMtvResponseBody = z.infer<
+    typeof MpeExportToMtvResponseBody
 >;
 
 export const MpeLeaveWorkflowRequestBody = z.object({

--- a/packages/types/src/mpe-temporal-to-server.ts
+++ b/packages/types/src/mpe-temporal-to-server.ts
@@ -1,5 +1,6 @@
 import * as z from 'zod';
 import { MpeWorkflowState } from './mpe';
+import { MtvRoomCreationOptionsWithoutInitialTracksIDs } from '.';
 
 export const MpeRejectAddingTracksRequestBody = z.object({
     roomID: z.string().uuid(),
@@ -52,6 +53,16 @@ export const MpeAcknowledgeJoinRequestBody = z.object({
 });
 export type MpeAcknowledgeJoinRequestBody = z.infer<
     typeof MpeAcknowledgeJoinRequestBody
+>;
+
+export const MpeRequestMtvRoomCreationRequestBody = z.object({
+    tracksIDs: z.array(z.string()),
+    userID: z.string().uuid(),
+    deviceID: z.string().uuid(),
+    mtvRoomOptions: MtvRoomCreationOptionsWithoutInitialTracksIDs,
+});
+export type MpeRequestMtvRoomCreationRequestBody = z.infer<
+    typeof MpeRequestMtvRoomCreationRequestBody
 >;
 
 export const MpeAcknowledgeLeaveRequestBody = z.object({

--- a/packages/types/src/mpe-temporal-to-server.ts
+++ b/packages/types/src/mpe-temporal-to-server.ts
@@ -1,6 +1,6 @@
 import * as z from 'zod';
 import { MpeWorkflowState } from './mpe';
-import { MtvRoomCreationOptionsWithoutInitialTracksIDs } from '.';
+import { MtvRoomCreationOptionsWithoutInitialTracksIDs } from './mpe-room-websockets';
 
 export const MpeRejectAddingTracksRequestBody = z.object({
     roomID: z.string().uuid(),


### PR DESCRIPTION
Closes #324 

## Notes

I created a single test, that ensures the user that exports a MPE room to a MTV room receives `MTV_CREATE_ROOM_CALLBACK` and `MTV_CREATE_ROOM_SYNCHED_CALLBACK` WS events.

I centralized the validation of mtv room creation options in a function called `validateMtvRoomOptions`. As we already tested that this validation process works properly specifically for direct MTV room creation, I decided to do not implement the same tests for MPE Export to MTV. It would have been better to do it also, but I think we can ignore writing these tests.