### PR TITLE
Refactor sign up server to send failure reason array

### DIFF
--- a/packages/server/app/Controllers/Http/AuthenticationController.ts
+++ b/packages/server/app/Controllers/Http/AuthenticationController.ts
@@ -48,7 +48,6 @@ export default class AuthenticationController {
             errors.push('UNAVAILABLE_NICKNAME');
         }
 
-        // Should we not check for related given email if it's already invalid ?
         const userWithGivenEmail = await User.findBy('email', email);
         if (userWithGivenEmail) {
             errors.push('UNAVAILABLE_EMAIL');

--- a/packages/server/app/Controllers/Http/AuthenticationController.ts
+++ b/packages/server/app/Controllers/Http/AuthenticationController.ts
@@ -2,6 +2,7 @@ import {
     SignUpResponseBody,
     UserSummary,
     SignUpRequestBody,
+    SignUpFailureReasons,
 } from '@musicroom/types';
 import User from 'App/Models/User';
 import { HttpContextContract } from '@ioc:Adonis/Core/HttpContext';
@@ -30,53 +31,46 @@ export default class AuthenticationController {
         response,
         auth,
     }: HttpContextContract): Promise<SignUpResponseBody> {
-        const safeParseResult = SignUpRequestBody.safeParse(request.body());
-
-        if (!safeParseResult.success) {
-            const parsedEmailIsInvalid = safeParseResult.error.errors.find(
-                (error) => error.message === 'INVALID_EMAIL',
-            );
-            if (parsedEmailIsInvalid) {
-                response.status(400);
-                return {
-                    status: 'INVALID_EMAIL',
-                };
-            }
-
-            throw safeParseResult.error;
-        }
-
         const { authenticationMode, email, password, userNickname } =
-            safeParseResult.data;
+            SignUpRequestBody.parse(request.body());
+        const errors: SignUpFailureReasons[] = [];
+
+        const emailIsInvalid = !z.string().email().max(255).check(email);
+        if (emailIsInvalid) {
+            errors.push('INVALID_EMAIL');
+        }
 
         const userWithGivenNickname = await User.findBy(
             'nickname',
             userNickname,
         );
-
         if (userWithGivenNickname) {
-            response.status(400);
-            return {
-                status: 'UNAVAILABLE_NICKNAME',
-            };
+            errors.push('UNAVAILABLE_NICKNAME');
         }
 
+        // Should we not check for related given email if it's already invalid ?
         const userWithGivenEmail = await User.findBy('email', email);
         if (userWithGivenEmail) {
-            response.status(400);
-            return {
-                status: 'UNAVAILABLE_EMAIL',
-            };
+            errors.push('UNAVAILABLE_EMAIL');
         }
 
         const passwordIsStrong = passwordStrengthRegex.test(password);
         const passwordIsNotStrong = !passwordIsStrong;
         if (passwordIsNotStrong) {
+            errors.push('WEAK_PASSWORD');
+        }
+
+        const signUpFailed = errors.length > 0;
+        if (signUpFailed) {
+            console.log(errors);
+
             response.status(400);
             return {
-                status: 'WEAK_PASSWORD',
+                status: 'FAILURE',
+                signFailureReasons: errors,
             };
         }
+        console.log('COULD NOT FIND ANY ERRORS');
 
         const { nickname, uuid: userID } = await User.create({
             nickname: userNickname,

--- a/packages/types/src/authentication.ts
+++ b/packages/types/src/authentication.ts
@@ -32,24 +32,34 @@ export type SignUpSuccessfullResponseBody = z.infer<
     typeof SignUpSuccessfullResponseBody
 >;
 
-export const SignUpResponseBody = z
-    .object({
-        status: z.enum([
-            'UNAVAILABLE_EMAIL',
-            'UNAVAILABLE_NICKNAME',
-            'INVALID_EMAIL',
-            'WEAK_PASSWORD',
-        ]),
-    })
-    .or(SignUpSuccessfullResponseBody);
+export const SignUpFailureReasons = z.enum([
+    'UNAVAILABLE_NICKNAME',
+    'UNAVAILABLE_EMAIL',
+    'INVALID_EMAIL',
+    'WEAK_PASSWORD',
+]);
+
+export type SignUpFailureReasons = z.infer<typeof SignUpFailureReasons>;
+
+export const SignUpFailureResponseBody = z.object({
+    status: z.literal('FAILURE'),
+    signFailureReasons: SignUpFailureReasons.array(),
+});
+
+export type SignUpFailureResponseBody = z.infer<
+    typeof SignUpFailureResponseBody
+>;
+
+export const SignUpResponseBody = SignUpFailureResponseBody.or(
+    SignUpSuccessfullResponseBody,
+);
+
 export type SignUpResponseBody = z.infer<typeof SignUpResponseBody>;
 
 export const SignUpRequestBody = z.object({
     userNickname: z.string(),
     password: z.string(),
-    email: z.string().email({ message: 'INVALID_EMAIL' }).max(255, {
-        message: 'INVALID_EMAIL',
-    }),
+    email: z.string(),
     authenticationMode: AuthenticationModeValues,
 });
 


### PR DESCRIPTION
Before the signup would failed on the first encountered exception
This is a new need for the UI
The user could have to re submit several time the same form to discover that some fields would fail weirdly between each attempt