### PR TITLE
global 30 minutes timeout for lint and tests job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 jobs:
     commitlint:
         runs-on: ubuntu-latest
+        timeout-minutes: 30
         steps:
             - name: Checkout 🛎
               uses: actions/checkout@v2


### PR DESCRIPTION
Added a global timeout for the ci lint and tests jobs as rarely the client tests will occurs into a infinite loop race conditions