### PR TITLE
mpe test-e fixing race conditions

### DIFF
--- a/packages/client/e2e/_utils/mock-http.ts
+++ b/packages/client/e2e/_utils/mock-http.ts
@@ -8,7 +8,10 @@ export interface KnownSearchesElement {
     duration: number;
 }
 
-export type knownSearchesRecordKey = 'Biolay - Vendredi 12' | 'BB Brunes';
+export type knownSearchesRecordKey =
+    | 'Biolay - Vendredi 12'
+    | 'BB Brunes'
+    | 'Madeleine';
 
 export type KnownSearchesRecord = Record<
     knownSearchesRecordKey,

--- a/packages/client/e2e/_utils/mpe-e2e-utils.ts
+++ b/packages/client/e2e/_utils/mpe-e2e-utils.ts
@@ -75,6 +75,39 @@ export const knownSearches: KnownSearchesRecord = {
             duration: 0,
         },
     ],
+
+    Madeleine: [
+        {
+            id: 'g8bS50c8v2s',
+            title: 'Jacques Brel Madeleine 1962',
+            artistName: 'Anastasio Eric',
+            duration: 0,
+        },
+        {
+            id: 'I7E1TV9giy4',
+            title: 'Omido - Madeleine (Lyrics) ft. Rick Jansen',
+            artistName: 'Cakes & Eclairs',
+            duration: 0,
+        },
+        {
+            id: 'RpJ-2U707pg',
+            title: 'Michael Phantom - Madeleine (Official Music Video) || VIEWS ||',
+            artistName: 'VIEWS',
+            duration: 0,
+        },
+        {
+            id: 'bdLHTAaMNdg',
+            title: 'Madeleine',
+            artistName: 'Jacques Brel - Topic',
+            duration: 0,
+        },
+        {
+            id: 'B49mIKWXc_8',
+            title: 'Madeleine - Ça va passer [CLIP OFFICIEL]',
+            artistName: 'itsmadeleine. love',
+            duration: 0,
+        },
+    ],
 };
 
 export async function pressMpeRoomInvitationToast({
@@ -402,7 +435,14 @@ export async function openMpeSettingsModal({
     const openSettingsButton = page.locator(
         `css=[data-testid="mpe-open-settings"]:not([aria-disabled="true"])`,
     );
-    // await expect(openSettingsButton).toBeVisible();
+    await expect(openSettingsButton).toBeVisible();
+    await expect(openSettingsButton).not.toHaveAttribute(
+        'aria-disabled',
+        'true',
+        {
+            timeout: 10_000,
+        },
+    );
 
     await openSettingsButton.click();
 
@@ -709,8 +749,9 @@ export async function addTrack({
         .first();
     await trackToAddCard.click();
 
+    const addedTrackTestID = `mpe-${trackToAdd.id}-track-card-container`;
     const addedTrackCardOnRoomScreen = page.locator(
-        withinMpeRoomScreen(`text=${trackToAddTitle}`),
+        `css=[data-testid="${addedTrackTestID}"]`,
     );
     await expect(addedTrackCardOnRoomScreen).toBeVisible({
         timeout: 10_000,

--- a/packages/client/e2e/mpe/test-e.spec.ts
+++ b/packages/client/e2e/mpe/test-e.spec.ts
@@ -142,7 +142,9 @@ async function exportMpeRoomToMtvRoom({
         page,
     });
 
-    const exportToMtvButton = page.locator('text="Export to MTV"');
+    const exportToMtvButton = page
+        .locator('css=[data-testid="export-mpe-to-mtv-button"]')
+        .last();
     await exportToMtvButton.click();
 
     await expect(
@@ -222,7 +224,7 @@ test('mpe e2e test-e', async ({ browser }) => {
 
     const addedTrack = await addTrack({
         page,
-        searchQuery: 'BB Brunes',
+        searchQuery: 'Madeleine',
     });
 
     await assertMusicPlayerStatusIs({

--- a/packages/client/e2e/sign-up.spec.ts
+++ b/packages/client/e2e/sign-up.spec.ts
@@ -5,6 +5,7 @@ import {
     knownSearches,
     pageIsOnHomeScreen,
     pageIsOnSignInScreen,
+    withinSignUpFormScreenContainer,
 } from './_utils/mpe-e2e-utils';
 import {
     bypassVerifyEmailScreen,
@@ -37,9 +38,21 @@ test('Signs up a user, expects to be redirected to home and to be still loggged 
 
     await expect(page.locator('text="To party sign up !"')).toBeVisible();
 
-    await page.fill('[placeholder="Nickname"]', internet.userName());
-    await page.fill('[placeholder="Email"]', internet.email());
-    await page.fill('[placeholder="Password"]', 'adfg=1435&*&*(SjhgA');
+    const userName = internet.userName();
+    await page.fill(
+        withinSignUpFormScreenContainer('[placeholder="Nickname"]'),
+        userName,
+    );
+    const email = internet.email();
+    await page.fill(
+        withinSignUpFormScreenContainer('[placeholder="Email"]'),
+        email,
+    );
+    const password = 'adfg=1435&*&*(SjhgA';
+    await page.fill(
+        withinSignUpFormScreenContainer('[placeholder="Password"]'),
+        password,
+    );
 
     await page.click('text="Sign Up"');
 
@@ -93,9 +106,21 @@ test('It should renders home on every browser tab after a signUp', async ({
 
     await expect(page.locator('text="To party sign up !"')).toBeVisible();
 
-    await page.fill('[placeholder="Nickname"]', internet.userName());
-    await page.fill('[placeholder="Email"]', internet.email());
-    await page.fill('[placeholder="Password"]', 'adfg=1435&*&*(SjhgA');
+    const userName = internet.userName();
+    await page.fill(
+        withinSignUpFormScreenContainer('[placeholder="Nickname"]'),
+        userName,
+    );
+    const email = internet.email();
+    await page.fill(
+        withinSignUpFormScreenContainer('[placeholder="Email"]'),
+        email,
+    );
+    const password = 'adfg=1435&*&*(SjhgA';
+    await page.fill(
+        withinSignUpFormScreenContainer('[placeholder="Password"]'),
+        password,
+    );
 
     await page.click('text="Sign Up"');
 


### PR DESCRIPTION
Test was failing mainly because we wanna add a track to the created mpe that has been used to created the current mtv room. Then the selector will stop on the mtv room mini music player instead of the mpe tracks search results
Also improved the test-e selectors 

also fixed e2e sign up tests issue where it sould target previous sign in screen input instead of the sign up one ! thanks @Devessier 