### PR TITLE
fix(client): android native app crash after nested redirections

### DIFF
--- a/packages/client/components/YouTubePlayer/native.tsx
+++ b/packages/client/components/YouTubePlayer/native.tsx
@@ -52,6 +52,9 @@ const NativePlayer: PlayerComponent = forwardRef<PlayerRef, PlayerProps>(
                 mute={mute}
                 //FIX for android see https://stackoverflow.com/questions/63171131/when-rendering-iframes-with-html-android-crashes-while-navigating-back-to-s
                 webViewStyle={{ opacity: 0.99 }}
+                webViewProps={{
+                    androidHardwareAccelerationDisabled: true,
+                }}
                 onReady={onReady}
             />
         );

--- a/packages/client/components/YouTubePlayer/native.tsx
+++ b/packages/client/components/YouTubePlayer/native.tsx
@@ -55,7 +55,11 @@ const NativePlayer: PlayerComponent = forwardRef<PlayerRef, PlayerProps>(
                 webViewProps={{
                     androidHardwareAccelerationDisabled: true,
                 }}
-                onReady={onReady}
+                onReady={() => {
+                    if (onReady) onReady();
+
+                    playerRef.current?.seekTo(seekToInSeconds, true);
+                }}
             />
         );
     },


### PR DESCRIPTION
# Android app crash after several redirection to a screen displaying iframe

We had an issue during a 42 correction on the android build, after joining an mtv successfully a first time if the user in the same app lifetime tries to rejoin an other or the same room after leaving it the app will crash with the following adb logs:

```
05-09 08:03:50.292  7196  7196 F crashpad: dlopen: dlopen failed: library "libandroidicu.so" not found: needed by /system/lib/libharfbuzz_ng.so in namespace (default)
05-09 08:03:50.292  6953  6999 F libc    : Fatal signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x1c in tid 6999 (RenderThread), pid 6953 (st.exp.exponent)
05-09 08:03:50.376  7199  7199 F DEBUG   : *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
05-09 08:03:50.377  7199  7199 F DEBUG   : Build fingerprint: 'google/sdk_gphone_x86_arm/generic_x86_arm:11/RSR1.201013.001/6903271:userdebug/dev-keys'
05-09 08:03:50.377  7199  7199 F DEBUG   : Revision: '0'
05-09 08:03:50.377  7199  7199 F DEBUG   : ABI: 'x86'
05-09 08:03:50.377  7199  7199 F DEBUG   : Timestamp: 2022-05-09 08:03:50+0200
05-09 08:03:50.377  7199  7199 F DEBUG   : pid: 6953, tid: 6999, name: RenderThread  >>> host.exp.exponent <<<
05-09 08:03:50.377  7199  7199 F DEBUG   : uid: 10153
05-09 08:03:50.377  7199  7199 F DEBUG   : signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x1c
05-09 08:03:50.377  7199  7199 F DEBUG   : Cause: null pointer dereference
05-09 08:03:50.377  7199  7199 F DEBUG   :     eax f5bd4f30  ebx f180da5c  ecx f1803e40  edx 00000000
05-09 08:03:50.377  7199  7199 F DEBUG   :     edi 7b650c90  esi 00000000
05-09 08:03:50.377  7199  7199 F DEBUG   :     ebp 7b650d38  esp 7b650b40  eip f11490d6
```

We could determine that the issue was normally already fixed using the opacity 0.99 workaround. It might not be enough there :o
Found several solution listed below:

##  `androidHardwareAccelerationDisabled`
Instead of modifying the android manifest we can inject inside the youtube player the corresponding config.

Source: [react-native-rendre-html issue](https://github.com/meliorence/react-native-render-html/issues/393)

## React navigation `animationEnabled`
Inside our react navigation config we could disabled those animations that leads to fix the issue

Source: [code utility article](https://codeutility.org/react-native-when-rendering-iframes-with-html-android-crashes-while-navigating-back-to-stack-screen-stack-overflow/)
